### PR TITLE
#249 PR2: explorer characterization tests

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -39,6 +39,30 @@ To test against a deployed site instead of a local render:
 TEST_URL=https://rdhyee.github.io/isamplesorg.github.io npx playwright test explorer-smoke
 ```
 
+## Running characterization & deeper specs via workflow_dispatch
+
+The characterization and deeper specs depend on live remote parquet loads and are **not**
+in the CI smoke gate.  They can be triggered via the GitHub Actions
+*Run workflow* button on the `explorer-e2e` workflow.  Set `spec_filter`
+to one of the values below; empty = all specs.
+
+| spec_filter value | What runs |
+|---|---|
+| `explorer-characterization` | PR2 characterization suite (7 [data] tests) |
+| `facet-viewport` | B1 viewport-aware facet counts (#234 step 3) |
+| `heatmap-overlay` | Heatmap mutual-exclusion and round-trip (#233) |
+| `search-real-count` | Search cap-hit real-count display (#232) |
+| `url-roundtrip` | URL state round-trip regressions (#209) |
+| `explorer-map-overlay` | Map overlay / table pagination (#200) |
+| *(empty)* | All Playwright specs (explorer + tutorial) |
+
+Run any of these locally with `npx playwright test <spec_filter>`, e.g.:
+
+    npx playwright test explorer-characterization
+
+Allow up to 3 minutes per test for remote parquet loads.
+
+
 ## Setup
 
 ### Install Dependencies

--- a/tests/playwright/explorer-characterization.spec.js
+++ b/tests/playwright/explorer-characterization.spec.js
@@ -1,27 +1,30 @@
 /**
  * Characterization tests for the iSamples Explorer (PR2, issue #249).
  *
- * These 7 tests (all tagged [data]) pin the 6 behaviors that Codex review
- * of the PR1 smoke gate explicitly named as missing characterization coverage.
- * They depend on remote parquet loads from data.isamples.org (202608 dataset)
- * and are intentionally NOT in the CI smoke gate (explorer-e2e.yml stays
- * unchanged).  Run manually or via workflow_dispatch with spec_filter=
- * explorer-characterization.
+ * These tests (all tagged [data]) pin the behaviors that Codex review of the
+ * PR1 smoke gate named as missing characterization coverage. They depend on
+ * remote parquet loads from data.isamples.org (202608 dataset) and are
+ * intentionally NOT in the CI smoke gate (explorer-e2e.yml stays unchanged).
+ * Run manually or via workflow_dispatch with spec_filter=explorer-characterization.
  *
- * Flakiness mitigations:
- *   - test.setTimeout(180000) for the whole describe block
- *   - expect.poll (60-90s) for every data-dependent assertion
- *   - NEVER fixed waitForTimeout for synchronisation
+ * Tightened per Codex PR2 review: every assertion pins an OBSERVABLE CONTRACT
+ * (the table actually filters; the deep-link propagates to the table; the
+ * detail card shows a real material), not just internal state that could
+ * false-pass during a refactor.
  *
- * Behavior map (7 tests total):
- *   (a+) search "pottery" -> __searchFilter.active + kind + tableMeta + tablePageInfo
- *   (a-) clear search    -> __searchFilter.active === false
- *   (b)  facet checkbox  -> aria-busy true->false, tablePageInfo changed
- *   (c)  heatmap         -> see heatmap-overlay.spec.js (comment only, no test)
- *   (d1) ?search= URL   -> __searchFilter.active + term restored
- *   (d2) &pid= URL      -> selectedPid restored + #inMapCard visible
- *   (e)  facet hydration -> >=3 source counts, material URIs, no .recomputing
- *   (f)  detail card    -> #inMapCard visible, #imcMaterial populated
+ * Flakiness mitigations: test.setTimeout(180000); expect.poll (60-90s) for
+ * every data-dependent assertion; NEVER fixed waitForTimeout.
+ *
+ * Behavior map:
+ *   (a+) search "pottery" -> __searchFilter active AND table total shrinks vs baseline
+ *   (a-) clear search     -> __searchFilter.active === false AND table total restored
+ *   (b)  material facet   -> table total strictly decreases (parsed ints), aria-busy settles false
+ *   (c)  heatmap          -> see heatmap-overlay.spec.js (comment only, no test)
+ *   (d1) ?search= URL     -> __searchFilter restored AND #tableMeta shows the match summary
+ *   (d2) &pid= URL        -> selectedPid restored AND #clusterSection shows the sample card
+ *                            (NB: deep-link does NOT open #inMapCard — row-click-only; gap filed)
+ *   (e)  facet hydration  -> >=3 source counts, material URIs, no stuck .recomputing
+ *   (f)  detail card      -> known sample -> #inMapCard visible AND exact material value
  */
 const { test, expect } = require('@playwright/test');
 const { explorerUrl } = require('./helpers/url');
@@ -36,163 +39,196 @@ const {
   getSelectedPid,
 } = require('./helpers/explorer');
 
+const WORLD = '#v=1&lat=20&lng=0&alt=10000000';
+
+// Parse the integer total out of #tablePageInfo: "Page 1 of N (1-100 of TOTAL)".
+async function tableTotal(page) {
+  const t = await page.locator('#tablePageInfo').textContent();
+  const m = t && t.match(/of ([\d,]+)\)\s*$/);
+  return m ? parseInt(m[1].replace(/,/g, ''), 10) : null;
+}
+// Poll until #tablePageInfo first shows a numeric total, return it.
+async function waitForTableTotal(page, timeout = 90000) {
+  await expect.poll(async () => await tableTotal(page), { timeout, intervals: [500, 1000, 2000] })
+    .toBeGreaterThan(0);
+  return await tableTotal(page);
+}
+
 test.describe('Explorer characterization tests [data]', () => {
   test.setTimeout(180000);
 
   // =========================================================================
-  // (a+) search-as-filter: submit "pottery" -> __searchFilter.active + table
+  // (a+) search-as-filter: a search must scope the TABLE to its matching set.
+  //      We use a deterministic known sample ("Object 5404-8" -> exactly the
+  //      one OpenContext record ark:/28722/k2p55x96j) so the proof is exact
+  //      and stable. (Table-total SCOPE shifts between viewport/global/filtered
+  //      states, so cross-state total comparisons are unreliable -- a known
+  //      single-result search is the robust way to prove real filtering.)
   // =========================================================================
-  test('(a+) [data] search "pottery" wires __searchFilter and updates table', async ({ page }) => {
-    await page.goto(explorerUrl(), { waitUntil: 'domcontentloaded', timeout: 60000 });
+  test('(a+) [data] search scopes the table to the matching record', async ({ page }) => {
+    await page.goto(explorerUrl(WORLD), { waitUntil: 'domcontentloaded', timeout: 60000 });
     await page.waitForSelector('#cesiumContainer', { timeout: 30000 });
+    await waitForBootReady(page);
     await waitForSearchReady(page, 90000);
-    await runSearch(page, 'pottery');
+    await runSearch(page, 'Object 5404-8');
 
-    // buildSearchFilter is async; poll until __searchFilter.active + kind settle.
+    // Internal state activates...
     await expect.poll(
       async () => { const sf = await getSearchFilter(page); return sf && sf.active && sf.kind === 'text'; },
       { timeout: 90000, intervals: [500, 1000, 2000] }
     ).toBe(true);
 
-    // #tableMeta: summaryText() when search active returns
-    // "N of M "pottery" matches in this map view." (explorer.qmd:2292).
+    // ...AND the table is scoped to exactly the one matching record...
     await expect.poll(
-      async () => await page.locator('#tableMeta').textContent(),
+      async () => await tableTotal(page),
       { timeout: 90000, intervals: [500, 1000, 2000] }
-    ).toMatch(/\d[\d,]* of [\d,]+ "pottery" match/);
+    ).toBe(1);
 
-    // #tablePageInfo: "Page 1 of N (1-100 of TOTAL)" total > 0.
-    await expect.poll(
-      async () => { const t = await page.locator('#tablePageInfo').textContent(); const m = t && t.match(/of ([\d,]+)\)$/); return m ? parseInt(m[1].replace(/,/g,''),10) : 0; },
-      { timeout: 90000, intervals: [500, 1000, 2000] }
-    ).toBeGreaterThan(0);
+    // ...which is the expected OpenContext sample.
+    await expect(page.locator('.samples-table tbody tr[data-pid="ark:/28722/k2p55x96j"]'))
+      .toBeVisible({ timeout: 30000 });
   });
 
   // =========================================================================
-  // (a-) negative: clear search -> __searchFilter.active === false
+  // (a-) negative: clearing a search removes the filter (active=false AND the
+  //      table grows beyond the single matched record).
   // =========================================================================
-  test('(a-) [data] clear search resets __searchFilter.active to false', async ({ page }) => {
-    await page.goto(explorerUrl(), { waitUntil: 'domcontentloaded', timeout: 60000 });
+  test('(a-) [data] clear search resets active=false and removes the filter', async ({ page }) => {
+    await page.goto(explorerUrl(WORLD), { waitUntil: 'domcontentloaded', timeout: 60000 });
     await page.waitForSelector('#cesiumContainer', { timeout: 30000 });
+    await waitForBootReady(page);
     await waitForSearchReady(page, 90000);
-    await runSearch(page, 'pottery');
 
-    // Wait for the search to activate first.
+    await runSearch(page, 'Object 5404-8');
     await expect.poll(
       async () => { const sf = await getSearchFilter(page); return sf && sf.active; },
       { timeout: 90000, intervals: [500, 1000, 2000] }
     ).toBe(true);
+    await expect.poll(async () => await tableTotal(page), { timeout: 90000, intervals: [500, 1000, 2000] })
+      .toBe(1);
 
-    // Now clear the search box and submit empty.
     const input = page.locator('#sampleSearch').first();
     await input.click();
     await input.press('ControlOrMeta+a');
     await input.press('Delete');
     await page.locator('#searchSubmitBtn').first().click();
 
-    // __searchFilter.active must go false after clear.
+    // Filter gone: active=false AND the table is no longer scoped to the 1 match.
     await expect.poll(
       async () => { const sf = await getSearchFilter(page); return sf ? sf.active : false; },
       { timeout: 60000, intervals: [500, 1000, 2000] }
     ).toBe(false);
+    await expect.poll(async () => await tableTotal(page), { timeout: 60000, intervals: [500, 1000, 2000] })
+      .toBeGreaterThan(1);
   });
 
   // =========================================================================
-  // (b) facet -> table coherence: material checkbox changes table total
+  // (b) facet -> table coherence: material checkbox STRICTLY decreases the
+  //     table total (parsed integers, not "text changed").
   // =========================================================================
-  test('(b) [data] material checkbox toggle changes table total', async ({ page }) => {
-    await page.goto(explorerUrl('#v=1&lat=20&lng=0&alt=10000000'), { waitUntil: 'domcontentloaded', timeout: 60000 });
+  test('(b) [data] material facet toggle strictly decreases table total', async ({ page }) => {
+    await page.goto(explorerUrl(WORLD), { waitUntil: 'domcontentloaded', timeout: 60000 });
     await page.waitForSelector('#cesiumContainer', { timeout: 30000 });
     await waitForBootReady(page);
 
-    // Wait for the table count to arrive.
-    await expect.poll(
-      async () => await page.locator('#tablePageInfo').textContent(),
-      { timeout: 90000, intervals: [500, 1000, 2000] }
-    ).toMatch(/Page 1 of \d+/);
-    const beforeText = await page.locator('#tablePageInfo').textContent();
+    const before = await waitForTableTotal(page, 90000);
 
-    // Tick the first material checkbox programmatically (the filter body may be
-    // visually collapsed so locator.check() would time out -- dispatch the change
-    // event on the container the same way facet-viewport.spec.js does for source).
     await page.waitForFunction(() => document.querySelectorAll('#materialFilterBody input[type="checkbox"]').length > 0, null, { timeout: 60000 });
-    await page.evaluate(() => { const cb = document.querySelector('#materialFilterBody input[type="checkbox"]'); if (cb) { cb.checked = true; document.getElementById('materialFilterBody').dispatchEvent(new Event('change', { bubbles: true })); } });
+    await page.evaluate(() => {
+      const cb = document.querySelector('#materialFilterBody input[type="checkbox"]');
+      if (cb) { cb.checked = true; document.getElementById('materialFilterBody').dispatchEvent(new Event('change', { bubbles: true })); }
+    });
 
-    // aria-busy transitions true -> false during the refetch.
-    await expect.poll(
-      async () => await page.locator('#tableContainer').getAttribute('aria-busy'),
-      { timeout: 30000, intervals: [100, 250, 500] }
-    ).toBe('true');
+    // Settle on the refetch (final aria-busy=false; the transient =true is not
+    // asserted -- a fast cached refresh can complete between polls, per Codex).
     await expect.poll(
       async () => await page.locator('#tableContainer').getAttribute('aria-busy'),
       { timeout: 90000, intervals: [250, 500, 1000] }
     ).toBe('false');
 
-    // Table total must have changed.
-    await expect.poll(
-      async () => await page.locator('#tablePageInfo').textContent(),
-      { timeout: 60000, intervals: [500, 1000, 2000] }
-    ).not.toBe(beforeText);
+    // Selecting ONE material facet must reduce the total (coherence), not just change text.
+    await expect.poll(async () => await tableTotal(page), { timeout: 60000, intervals: [500, 1000, 2000] })
+      .toBeLessThan(before);
+    expect(await tableTotal(page)).toBeGreaterThan(0);
   });
 
   // =========================================================================
-  // (c) heatmap -- already fully covered by heatmap-overlay.spec.js; see there
-  //     for: toggle on/off, mutual exclusion with markers, URL round-trip,
-  //     filter changes regenerate the heatmap, world-view no-cap assertion.
+  // (c) heatmap -- fully covered by heatmap-overlay.spec.js (toggle, mutual
+  //     exclusion with markers, URL round-trip, no-cap). Not duplicated here.
   // =========================================================================
 
   // =========================================================================
-  // (d1) deep-link ?search=pottery -> restores __searchFilter state
+  // (d1) deep-link ?search=pottery -> restores state AND propagates to the table
+  //      (#tableMeta shows the match summary, not just the internal flag).
   // =========================================================================
-  test('(d1) [data] ?search=pottery deep-link restores __searchFilter.active + term', async ({ page }) => {
-    await page.goto(explorerUrl('?search=pottery#v=1&lat=20&lng=0&alt=10000000'), { waitUntil: 'domcontentloaded', timeout: 60000 });
+  test('(d1) [data] ?search=pottery deep-link restores state AND filters the table', async ({ page }) => {
+    await page.goto(explorerUrl('?search=pottery' + WORLD), { waitUntil: 'domcontentloaded', timeout: 60000 });
     await page.waitForSelector('#cesiumContainer', { timeout: 30000 });
 
-    // Boot reads search= from the URL and calls buildSearchFilter (async).
     await expect.poll(
       async () => { const sf = await getSearchFilter(page); return sf && sf.active && sf.term === 'pottery'; },
       { timeout: 90000, intervals: [500, 1000, 2000] }
     ).toBe(true);
+
+    // Propagation: the table surface reflects the deep-linked search.
+    await expect.poll(
+      async () => await page.locator('#tableMeta').textContent(),
+      { timeout: 90000, intervals: [500, 1000, 2000] }
+    ).toMatch(/\d[\d,]* of [\d,]+ "pottery" match/);
   });
 
   // =========================================================================
-  // (d2) deep-link &pid= -> restores selectedPid + shows #inMapCard
+  // (d2) deep-link &pid= -> restores selectedPid AND renders the sample card
+  //      into #clusterSection (what the boot/hashchange pid path actually does:
+  //      updateSampleCard, NOT showInMapCard). The fact that a pid deep-link
+  //      does NOT open #inMapCard (whereas a row-click does) is a real UX
+  //      inconsistency tracked as a follow-up (#239-family), NOT asserted here.
   // =========================================================================
-  test.fixme('(d2) [data] &pid= deep-link restores selectedPid and shows #inMapCard', async ({ browser }) => {
-    // Phase 1: navigate, click a row, capture pid + URL.
+  test('(d2) [data] &pid= deep-link restores selectedPid and renders #clusterSection card', async ({ browser }) => {
+    // Phase 1: click a row, capture pid + label + the resulting pid URL.
     const ctx1 = await browser.newContext();
-    let capturedUrl = null;
-    let capturedPid = null;
+    let capturedUrl = null, capturedPid = null, capturedLabel = null;
     try {
       const page1 = await ctx1.newPage();
-      await page1.goto(explorerUrl('#v=1&lat=20&lng=0&alt=10000000'), { waitUntil: 'domcontentloaded', timeout: 60000 });
+      await page1.goto(explorerUrl(WORLD), { waitUntil: 'domcontentloaded', timeout: 60000 });
       await page1.waitForSelector('#cesiumContainer', { timeout: 30000 });
       await waitForBootReady(page1);
       const firstRow = page1.locator('.samples-table tbody tr[data-pid]').first();
       await expect(firstRow).toBeVisible({ timeout: 90000 });
       capturedPid = await firstRow.getAttribute('data-pid');
+      capturedLabel = (await firstRow.locator('td').nth(1).textContent() || '').trim();
       expect(capturedPid).toBeTruthy();
       await firstRow.locator('td').first().click();
       await expect.poll(async () => await page1.evaluate(() => location.href), { timeout: 30000, intervals: [250, 500, 1000] }).toContain('pid=');
       capturedUrl = await page1.evaluate(() => location.href);
     } finally { await ctx1.close(); }
 
-    // Phase 2: load the captured URL, assert state is restored.
+    // Phase 2: load the pid URL fresh; assert the boot pid path restored state + card.
     const ctx2 = await browser.newContext();
     try {
       const page2 = await ctx2.newPage();
       await page2.goto(capturedUrl, { waitUntil: 'domcontentloaded', timeout: 60000 });
       await page2.waitForSelector('#cesiumContainer', { timeout: 30000 });
       await waitForBootReady(page2);
+      // selectedPid restored.
       await expect.poll(async () => await getSelectedPid(page2), { timeout: 90000, intervals: [500, 1000, 2000] }).toBe(capturedPid);
-      // The pid boot path fetches lite parquet before calling updateSampleCard();
-      // allow up to 120s for the query to complete and set el.hidden = false.
-      await expect.poll(async () => await page2.locator('#inMapCard').getAttribute('hidden'), { timeout: 120000, intervals: [500, 1000, 2000] }).toBeNull();
+      // updateSampleCard rendered the sample into #clusterSection (the real visible effect).
+      await expect.poll(
+        async () => await page2.evaluate(() => { const el = document.getElementById('clusterSection'); return el ? el.querySelector('.cluster-card') !== null : false; }),
+        { timeout: 120000, intervals: [500, 1000, 2000] }
+      ).toBe(true);
+      // and the card carries the deep-linked sample's label.
+      if (capturedLabel) {
+        await expect.poll(
+          async () => await page2.locator('#clusterSection').textContent(),
+          { timeout: 30000, intervals: [500, 1000] }
+        ).toContain(capturedLabel);
+      }
     } finally { await ctx2.close(); }
   });
 
   // =========================================================================
-  // (e) facet hydration: source counts, material URIs, no .recomputing
+  // (e) facet hydration: source counts, material URIs, no stuck .recomputing
   // =========================================================================
   test('(e) [data] facet hydration: source counts, material URIs, no stuck .recomputing', async ({ page }) => {
     await page.goto(explorerUrl('#v=1&lat=0&lng=0&alt=15000000'), { waitUntil: 'domcontentloaded', timeout: 60000 });
@@ -200,49 +236,43 @@ test.describe('Explorer characterization tests [data]', () => {
     await waitForFacetUI(page, 90000);
     await waitForFacetCountsStable(page, 90000);
 
-    // At least 3 source facet counts must be > 0.
     const sourceCounts = await readFacetCounts(page, 'source');
     expect(Object.values(sourceCounts).filter(n => n > 0).length).toBeGreaterThanOrEqual(3);
 
-    // All material checkbox values must be full https:// URIs.
     const materialValues = await page.evaluate(() => [...document.querySelectorAll('#materialFilterBody input[type="checkbox"]')].map(cb => cb.value));
     expect(materialValues.length).toBeGreaterThan(0);
     for (const val of materialValues) { expect(val).toMatch(/^https?:\/\//); }
 
-    // Zero stuck .recomputing after stable.
     const stuck = await page.evaluate(() => document.querySelectorAll('.facet-count.recomputing').length);
     expect(stuck).toBe(0);
   });
 
   // =========================================================================
-  // (f) detail card: row click shows #inMapCard + populates #imcMaterial
+  // (f) detail card: a KNOWN sample (#260, ark:/28722/k2p55x96j) must show the
+  //     in-map card with its EXACT material -- not merely "non-empty", which
+  //     would false-pass on "Not Provided" from a failed detail query (Codex).
   // =========================================================================
-  test('(f) [data] row click shows #inMapCard and populates #imcMaterial', async ({ page }) => {
-    await page.goto(explorerUrl('#v=1&lat=20&lng=0&alt=10000000'), { waitUntil: 'domcontentloaded', timeout: 60000 });
+  test('(f) [data] known sample row-click shows #inMapCard with exact material', async ({ page }) => {
+    await page.goto(explorerUrl('?search=Object+5404-8' + WORLD), { waitUntil: 'domcontentloaded', timeout: 60000 });
     await page.waitForSelector('#cesiumContainer', { timeout: 30000 });
-    await waitForBootReady(page);
+    await waitForSearchReady(page, 90000);
 
-    // Wait for at least one data row.
-    const firstRow = page.locator('.samples-table tbody tr[data-pid]').first();
-    await expect(firstRow).toBeVisible({ timeout: 90000 });
+    // The deep-link search resolves to exactly this OpenContext sample.
+    const row = page.locator('.samples-table tbody tr[data-pid="ark:/28722/k2p55x96j"]');
+    await expect(row).toBeVisible({ timeout: 120000 });
 
-    // Verify #inMapCard starts hidden (has the HTML hidden attribute).
-    expect(await page.locator('#inMapCard').getAttribute('hidden')).not.toBeNull();
+    expect(await page.locator('#inMapCard').getAttribute('hidden')).not.toBeNull(); // starts hidden
+    await row.locator('td').first().click();
 
-    // Click the first cell (avoids intercepting <a> links in label cells).
-    await firstRow.locator('td').first().click();
-
-    // #inMapCard should no longer be hidden (the hidden attribute is removed).
     await expect.poll(
       async () => await page.locator('#inMapCard').getAttribute('hidden'),
       { timeout: 60000, intervals: [250, 500, 1000] }
     ).toBeNull();
 
-    // #imcMaterial starts as '—' (setText placeholder) and should populate
-    // once the async wide-parquet detail fetch completes (explorer.qmd:1459).
+    // Exact, known material (the #260 fix value) -- pins a real successful detail query.
     await expect.poll(
-      async () => { const t = await page.locator('#imcMaterial').textContent(); return t && t.trim() !== '' && t.trim() !== '—'; },
+      async () => (await page.locator('#imcMaterial').textContent() || '').trim(),
       { timeout: 90000, intervals: [500, 1000, 2000] }
-    ).toBe(true);
+    ).toBe('Other anthropogenic material');
   });
 });

--- a/tests/playwright/explorer-characterization.spec.js
+++ b/tests/playwright/explorer-characterization.spec.js
@@ -16,8 +16,8 @@
  * every data-dependent assertion; NEVER fixed waitForTimeout.
  *
  * Behavior map:
- *   (a+) search "pottery" -> __searchFilter active AND table total shrinks vs baseline
- *   (a-) clear search     -> __searchFilter.active === false AND table total restored
+ *   (a+) search (known single result) -> __searchFilter active AND table total == 1
+ *   (a-) clear search     -> __searchFilter.active === false AND filter removed (total > 1)
  *   (b)  material facet   -> table total strictly decreases (parsed ints), aria-busy settles false
  *   (c)  heatmap          -> see heatmap-overlay.spec.js (comment only, no test)
  *   (d1) ?search= URL     -> __searchFilter restored AND #tableMeta shows the match summary

--- a/tests/playwright/explorer-characterization.spec.js
+++ b/tests/playwright/explorer-characterization.spec.js
@@ -1,0 +1,248 @@
+/**
+ * Characterization tests for the iSamples Explorer (PR2, issue #249).
+ *
+ * These 7 tests (all tagged [data]) pin the 6 behaviors that Codex review
+ * of the PR1 smoke gate explicitly named as missing characterization coverage.
+ * They depend on remote parquet loads from data.isamples.org (202608 dataset)
+ * and are intentionally NOT in the CI smoke gate (explorer-e2e.yml stays
+ * unchanged).  Run manually or via workflow_dispatch with spec_filter=
+ * explorer-characterization.
+ *
+ * Flakiness mitigations:
+ *   - test.setTimeout(180000) for the whole describe block
+ *   - expect.poll (60-90s) for every data-dependent assertion
+ *   - NEVER fixed waitForTimeout for synchronisation
+ *
+ * Behavior map (7 tests total):
+ *   (a+) search "pottery" -> __searchFilter.active + kind + tableMeta + tablePageInfo
+ *   (a-) clear search    -> __searchFilter.active === false
+ *   (b)  facet checkbox  -> aria-busy true->false, tablePageInfo changed
+ *   (c)  heatmap         -> see heatmap-overlay.spec.js (comment only, no test)
+ *   (d1) ?search= URL   -> __searchFilter.active + term restored
+ *   (d2) &pid= URL      -> selectedPid restored + #inMapCard visible
+ *   (e)  facet hydration -> >=3 source counts, material URIs, no .recomputing
+ *   (f)  detail card    -> #inMapCard visible, #imcMaterial populated
+ */
+const { test, expect } = require('@playwright/test');
+const { explorerUrl } = require('./helpers/url');
+const {
+  waitForBootReady,
+  waitForFacetUI,
+  waitForFacetCountsStable,
+  readFacetCounts,
+  waitForSearchReady,
+  runSearch,
+  getSearchFilter,
+  getSelectedPid,
+} = require('./helpers/explorer');
+
+test.describe('Explorer characterization tests [data]', () => {
+  test.setTimeout(180000);
+
+  // =========================================================================
+  // (a+) search-as-filter: submit "pottery" -> __searchFilter.active + table
+  // =========================================================================
+  test('(a+) [data] search "pottery" wires __searchFilter and updates table', async ({ page }) => {
+    await page.goto(explorerUrl(), { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await page.waitForSelector('#cesiumContainer', { timeout: 30000 });
+    await waitForSearchReady(page, 90000);
+    await runSearch(page, 'pottery');
+
+    // buildSearchFilter is async; poll until __searchFilter.active + kind settle.
+    await expect.poll(
+      async () => { const sf = await getSearchFilter(page); return sf && sf.active && sf.kind === 'text'; },
+      { timeout: 90000, intervals: [500, 1000, 2000] }
+    ).toBe(true);
+
+    // #tableMeta: summaryText() when search active returns
+    // "N of M "pottery" matches in this map view." (explorer.qmd:2292).
+    await expect.poll(
+      async () => await page.locator('#tableMeta').textContent(),
+      { timeout: 90000, intervals: [500, 1000, 2000] }
+    ).toMatch(/\d[\d,]* of [\d,]+ "pottery" match/);
+
+    // #tablePageInfo: "Page 1 of N (1-100 of TOTAL)" total > 0.
+    await expect.poll(
+      async () => { const t = await page.locator('#tablePageInfo').textContent(); const m = t && t.match(/of ([\d,]+)\)$/); return m ? parseInt(m[1].replace(/,/g,''),10) : 0; },
+      { timeout: 90000, intervals: [500, 1000, 2000] }
+    ).toBeGreaterThan(0);
+  });
+
+  // =========================================================================
+  // (a-) negative: clear search -> __searchFilter.active === false
+  // =========================================================================
+  test('(a-) [data] clear search resets __searchFilter.active to false', async ({ page }) => {
+    await page.goto(explorerUrl(), { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await page.waitForSelector('#cesiumContainer', { timeout: 30000 });
+    await waitForSearchReady(page, 90000);
+    await runSearch(page, 'pottery');
+
+    // Wait for the search to activate first.
+    await expect.poll(
+      async () => { const sf = await getSearchFilter(page); return sf && sf.active; },
+      { timeout: 90000, intervals: [500, 1000, 2000] }
+    ).toBe(true);
+
+    // Now clear the search box and submit empty.
+    const input = page.locator('#sampleSearch').first();
+    await input.click();
+    await input.press('ControlOrMeta+a');
+    await input.press('Delete');
+    await page.locator('#searchSubmitBtn').first().click();
+
+    // __searchFilter.active must go false after clear.
+    await expect.poll(
+      async () => { const sf = await getSearchFilter(page); return sf ? sf.active : false; },
+      { timeout: 60000, intervals: [500, 1000, 2000] }
+    ).toBe(false);
+  });
+
+  // =========================================================================
+  // (b) facet -> table coherence: material checkbox changes table total
+  // =========================================================================
+  test('(b) [data] material checkbox toggle changes table total', async ({ page }) => {
+    await page.goto(explorerUrl('#v=1&lat=20&lng=0&alt=10000000'), { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await page.waitForSelector('#cesiumContainer', { timeout: 30000 });
+    await waitForBootReady(page);
+
+    // Wait for the table count to arrive.
+    await expect.poll(
+      async () => await page.locator('#tablePageInfo').textContent(),
+      { timeout: 90000, intervals: [500, 1000, 2000] }
+    ).toMatch(/Page 1 of \d+/);
+    const beforeText = await page.locator('#tablePageInfo').textContent();
+
+    // Tick the first material checkbox programmatically (the filter body may be
+    // visually collapsed so locator.check() would time out -- dispatch the change
+    // event on the container the same way facet-viewport.spec.js does for source).
+    await page.waitForFunction(() => document.querySelectorAll('#materialFilterBody input[type="checkbox"]').length > 0, null, { timeout: 60000 });
+    await page.evaluate(() => { const cb = document.querySelector('#materialFilterBody input[type="checkbox"]'); if (cb) { cb.checked = true; document.getElementById('materialFilterBody').dispatchEvent(new Event('change', { bubbles: true })); } });
+
+    // aria-busy transitions true -> false during the refetch.
+    await expect.poll(
+      async () => await page.locator('#tableContainer').getAttribute('aria-busy'),
+      { timeout: 30000, intervals: [100, 250, 500] }
+    ).toBe('true');
+    await expect.poll(
+      async () => await page.locator('#tableContainer').getAttribute('aria-busy'),
+      { timeout: 90000, intervals: [250, 500, 1000] }
+    ).toBe('false');
+
+    // Table total must have changed.
+    await expect.poll(
+      async () => await page.locator('#tablePageInfo').textContent(),
+      { timeout: 60000, intervals: [500, 1000, 2000] }
+    ).not.toBe(beforeText);
+  });
+
+  // =========================================================================
+  // (c) heatmap -- already fully covered by heatmap-overlay.spec.js; see there
+  //     for: toggle on/off, mutual exclusion with markers, URL round-trip,
+  //     filter changes regenerate the heatmap, world-view no-cap assertion.
+  // =========================================================================
+
+  // =========================================================================
+  // (d1) deep-link ?search=pottery -> restores __searchFilter state
+  // =========================================================================
+  test('(d1) [data] ?search=pottery deep-link restores __searchFilter.active + term', async ({ page }) => {
+    await page.goto(explorerUrl('?search=pottery#v=1&lat=20&lng=0&alt=10000000'), { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await page.waitForSelector('#cesiumContainer', { timeout: 30000 });
+
+    // Boot reads search= from the URL and calls buildSearchFilter (async).
+    await expect.poll(
+      async () => { const sf = await getSearchFilter(page); return sf && sf.active && sf.term === 'pottery'; },
+      { timeout: 90000, intervals: [500, 1000, 2000] }
+    ).toBe(true);
+  });
+
+  // =========================================================================
+  // (d2) deep-link &pid= -> restores selectedPid + shows #inMapCard
+  // =========================================================================
+  test.fixme('(d2) [data] &pid= deep-link restores selectedPid and shows #inMapCard', async ({ browser }) => {
+    // Phase 1: navigate, click a row, capture pid + URL.
+    const ctx1 = await browser.newContext();
+    let capturedUrl = null;
+    let capturedPid = null;
+    try {
+      const page1 = await ctx1.newPage();
+      await page1.goto(explorerUrl('#v=1&lat=20&lng=0&alt=10000000'), { waitUntil: 'domcontentloaded', timeout: 60000 });
+      await page1.waitForSelector('#cesiumContainer', { timeout: 30000 });
+      await waitForBootReady(page1);
+      const firstRow = page1.locator('.samples-table tbody tr[data-pid]').first();
+      await expect(firstRow).toBeVisible({ timeout: 90000 });
+      capturedPid = await firstRow.getAttribute('data-pid');
+      expect(capturedPid).toBeTruthy();
+      await firstRow.locator('td').first().click();
+      await expect.poll(async () => await page1.evaluate(() => location.href), { timeout: 30000, intervals: [250, 500, 1000] }).toContain('pid=');
+      capturedUrl = await page1.evaluate(() => location.href);
+    } finally { await ctx1.close(); }
+
+    // Phase 2: load the captured URL, assert state is restored.
+    const ctx2 = await browser.newContext();
+    try {
+      const page2 = await ctx2.newPage();
+      await page2.goto(capturedUrl, { waitUntil: 'domcontentloaded', timeout: 60000 });
+      await page2.waitForSelector('#cesiumContainer', { timeout: 30000 });
+      await waitForBootReady(page2);
+      await expect.poll(async () => await getSelectedPid(page2), { timeout: 90000, intervals: [500, 1000, 2000] }).toBe(capturedPid);
+      // The pid boot path fetches lite parquet before calling updateSampleCard();
+      // allow up to 120s for the query to complete and set el.hidden = false.
+      await expect.poll(async () => await page2.locator('#inMapCard').getAttribute('hidden'), { timeout: 120000, intervals: [500, 1000, 2000] }).toBeNull();
+    } finally { await ctx2.close(); }
+  });
+
+  // =========================================================================
+  // (e) facet hydration: source counts, material URIs, no .recomputing
+  // =========================================================================
+  test('(e) [data] facet hydration: source counts, material URIs, no stuck .recomputing', async ({ page }) => {
+    await page.goto(explorerUrl('#v=1&lat=0&lng=0&alt=15000000'), { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await page.waitForSelector('#cesiumContainer', { timeout: 30000 });
+    await waitForFacetUI(page, 90000);
+    await waitForFacetCountsStable(page, 90000);
+
+    // At least 3 source facet counts must be > 0.
+    const sourceCounts = await readFacetCounts(page, 'source');
+    expect(Object.values(sourceCounts).filter(n => n > 0).length).toBeGreaterThanOrEqual(3);
+
+    // All material checkbox values must be full https:// URIs.
+    const materialValues = await page.evaluate(() => [...document.querySelectorAll('#materialFilterBody input[type="checkbox"]')].map(cb => cb.value));
+    expect(materialValues.length).toBeGreaterThan(0);
+    for (const val of materialValues) { expect(val).toMatch(/^https?:\/\//); }
+
+    // Zero stuck .recomputing after stable.
+    const stuck = await page.evaluate(() => document.querySelectorAll('.facet-count.recomputing').length);
+    expect(stuck).toBe(0);
+  });
+
+  // =========================================================================
+  // (f) detail card: row click shows #inMapCard + populates #imcMaterial
+  // =========================================================================
+  test('(f) [data] row click shows #inMapCard and populates #imcMaterial', async ({ page }) => {
+    await page.goto(explorerUrl('#v=1&lat=20&lng=0&alt=10000000'), { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await page.waitForSelector('#cesiumContainer', { timeout: 30000 });
+    await waitForBootReady(page);
+
+    // Wait for at least one data row.
+    const firstRow = page.locator('.samples-table tbody tr[data-pid]').first();
+    await expect(firstRow).toBeVisible({ timeout: 90000 });
+
+    // Verify #inMapCard starts hidden (has the HTML hidden attribute).
+    expect(await page.locator('#inMapCard').getAttribute('hidden')).not.toBeNull();
+
+    // Click the first cell (avoids intercepting <a> links in label cells).
+    await firstRow.locator('td').first().click();
+
+    // #inMapCard should no longer be hidden (the hidden attribute is removed).
+    await expect.poll(
+      async () => await page.locator('#inMapCard').getAttribute('hidden'),
+      { timeout: 60000, intervals: [250, 500, 1000] }
+    ).toBeNull();
+
+    // #imcMaterial starts as '—' (setText placeholder) and should populate
+    // once the async wide-parquet detail fetch completes (explorer.qmd:1459).
+    await expect.poll(
+      async () => { const t = await page.locator('#imcMaterial').textContent(); return t && t.trim() !== '' && t.trim() !== '—'; },
+      { timeout: 90000, intervals: [500, 1000, 2000] }
+    ).toBe(true);
+  });
+});

--- a/tests/playwright/helpers/explorer.js
+++ b/tests/playwright/helpers/explorer.js
@@ -1,0 +1,331 @@
+// Explorer-specific Playwright helpers.
+//
+// Consolidates helpers that were copy-pasted across multiple spec files so
+// `explorer-characterization.spec.js` (and future specs) can import them
+// without duplicating the implementation.  Every function below is copied
+// verbatim from the source spec noted in the block comment; the source spec
+// keeps its own inline copy (unchanged) so existing tests remain independent.
+//
+// Module style follows `tests/playwright/helpers/url.js`:
+//   - CommonJS (require/module.exports)
+//   - No external dependencies beyond Playwright's `page` argument
+//   - Each helper is exported by name
+//
+// Source specs:
+//   explorer-map-overlay.spec.js  -> waitForBootReady
+//   facet-viewport.spec.js        -> waitForFacetUI, waitForFacetCountsStable,
+//                                    readFacetCounts
+//   heatmap-overlay.spec.js       -> heatmapState, markerVisibility
+//   url-roundtrip.spec.js         -> waitForMode, snapshot
+//   search-real-count.spec.js     -> waitForSearchReady, runSearch
+//
+// NEW helpers (not in any existing spec):
+//   getSearchFilter -> reads window.__searchFilter
+//   getSelectedPid  -> reads viewer._globeState.selectedPid via OJS mainModule
+
+// ---------------------------------------------------------------------------
+// From explorer-map-overlay.spec.js
+// ---------------------------------------------------------------------------
+
+/** Wait for the OJS runtime to attach, then wait for zoomWatcher to resolve
+ *  (it returns "active" once boot hydration + listener registration are
+ *  complete - same pattern used in explorer-layout-stability.spec.js). */
+async function waitForBootReady(page) {
+  // Wait for the OJS runtime to attach, then wait for zoomWatcher to resolve
+  // (it returns "active" once boot hydration + listener registration are
+  // complete - same pattern used in explorer-layout-stability.spec.js).
+  await page.waitForFunction(() => !!window._ojs && !!window._ojs.ojsConnector, null, { timeout: 60000 });
+  await page.evaluate(async () => {
+    return await window._ojs.ojsConnector.mainModule.value('zoomWatcher');
+  });
+}
+// ---------------------------------------------------------------------------
+// From facet-viewport.spec.js
+// ---------------------------------------------------------------------------
+
+/** Wait until facet UI hydrates: at least one `.facet-count[data-facet="source"]`
+ *  span is in the DOM. The facetFilters cell renders these after
+ *  facet_summaries.parquet loads, which is the same precondition existing
+ *  tests (facetnote-url-load) wait for. */
+async function waitForFacetUI(page, ms = 60000) {
+    await page.waitForFunction(
+        () => document.querySelectorAll('.facet-count[data-facet="source"]').length > 0,
+        null, { timeout: ms }
+    );
+    // Also wait for materialFilterBody to populate - the existing
+    // facetnote-url-load spec uses this as the "facet UI is fully wired"
+    // signal, and we want to match its boot-readiness criterion.
+    await page.waitForFunction(
+        () => document.querySelectorAll('#materialFilterBody input[type="checkbox"]').length > 0,
+        null, { timeout: ms }
+    );
+}
+
+async function waitForFacetCountsStable(page, ms = 60000) {
+    await page.waitForFunction(
+        () => document.querySelectorAll('.facet-count.recomputing').length === 0,
+        null, { timeout: ms }
+    );
+}
+
+/** Read the per-value counts for a facet off the DOM. Returns `{[uri]: integer}`.
+ *  Tolerates the `Number.toLocaleString()` thousands-grouping the renderer
+ *  applies (en-US locale produces `1,234`; we strip commas). */
+async function readFacetCounts(page, facet) {
+    return page.evaluate((facet) => {
+        const out = {};
+        document.querySelectorAll(`.facet-count[data-facet="${facet}"]`).forEach(el => {
+            const val = el.getAttribute('data-value');
+            const m = (el.textContent || '').match(/\(([\d,]+)\)/);
+            if (m && val) out[val] = parseInt(m[1].replace(/,/g, ''), 10);
+        });
+        return out;
+    }, facet);
+}
+
+/** Source is the most stable facet for the unfiltered viewport-aware
+ *  assertion: only a handful of values, and `_baselineCounts.source`
+ *  populates at boot. */
+async function readSourceCounts(page) { return readFacetCounts(page, 'source'); }
+
+/** flyTo a destination, then wait for the post-moveEnd debounce + bbox query
+ *  to settle. Uses a zero-duration flight to make the test deterministic. */
+async function flyToAndSettle(page, lat, lng, alt) {
+    await page.evaluate(async ({ lat, lng, alt }) => {
+        const v = await window._ojs?.ojsConnector?.mainModule?.value('viewer');
+        if (!v) throw new Error('viewer not in OJS module');
+        v.camera.flyTo({
+            destination: window.Cesium.Cartesian3.fromDegrees(lng, lat, alt),
+            duration: 0,
+        });
+    }, { lat, lng, alt });
+    // Give the debounce + query a chance to land. waitForFacetCountsStable
+    // is the real synchronization point; this just kicks the event loop.
+    await page.waitForTimeout(50);
+    await waitForFacetCountsStable(page);
+}
+
+
+// ---------------------------------------------------------------------------
+// From heatmap-overlay.spec.js
+// ---------------------------------------------------------------------------
+
+async function heatmapState(page) {
+    await page.waitForFunction(() => !!window._ojs?.ojsConnector?.mainModule, null, { timeout: 60000 });
+    return await page.evaluate(() => {
+      return window._ojs.ojsConnector.mainModule.value('viewer').then((v) => {
+        const state = v?._heatmapOverlay || {};
+        return {
+          enabled: !!state.enabled,
+          hasLayer: !!state.layer,
+          layerShown: state.layer ? state.layer.show !== false : false,
+          lastRefreshAt: state.lastRefreshAt || 0,
+          lastPointCount: state.lastPointCount || 0,
+          lastImageHash: state.lastImageHash || null,
+          status: document.getElementById('heatmapStatus')?.textContent || '',
+        };
+      });
+    });
+  }
+
+// Reads the live `.show` flags off the two marker collections so a test
+  // can assert mutual exclusion with the heatmap overlay (#233 phase 3).
+async function markerVisibility(page) {
+    return await page.evaluate(() => {
+      return window._ojs.ojsConnector.mainModule.value('viewer').then((v) => ({
+        clusterShown: v?.h3Points?.show === true,
+        pointShown: v?.samplePoints?.show === true,
+        mode: v?._globeState?.mode || null,
+      }));
+    });
+  }
+
+
+// ---------------------------------------------------------------------------
+// From url-roundtrip.spec.js
+// ---------------------------------------------------------------------------
+
+/** Wait until `viewer._globeState.mode` equals `expected`.
+ *  Cold-cache point-mode boot can take 60–90s per #190; allow 3 minutes. */
+async function waitForMode(page, expected, timeoutMs = 180000) {
+  await page.waitForFunction(
+    async (expectedMode) => {
+      try {
+        const v = await window._ojs?.ojsConnector?.mainModule?.value('viewer');
+        return v?._globeState?.mode === expectedMode;
+      } catch { return false; }
+    },
+    expected,
+    { timeout: timeoutMs }
+  );
+}
+
+/** Wait until `loadViewportSamples` has settled into the point-mode done message.
+ *  Matches on the trailing "Click one for details" phrase — it's the common
+ *  denominator across both done-state phaseMsg branches at explorer.qmd:1610-1612
+ *  (normal: `"<n> individual samples. Click one for details."` and cap-reached:
+ *  `"<n> samples in view (showing m — zoom in for more). Click one for details."`).
+ *  Codex review (PR #214 round 1) suggested switching to the count phrase
+ *  `\d[\d,]*\s+individual\s+samples`, but that pattern misses the cap-reached
+ *  branch which has no "individual" word, so we stay with the trailing phrase. */
+async function waitForPointModeSettled(page, timeoutMs = 120000) {
+  await page.waitForFunction(
+    () => {
+      const msg = document.getElementById('phaseMsg')?.textContent || '';
+      return msg.includes('Click one for details');
+    },
+    null,
+    { timeout: timeoutMs }
+  );
+}
+
+/** Wait for boot to complete enough that the `hashchange` listener (registered
+ *  late in the explorer cell at explorer.qmd:2210) is installed. `_globeState`
+ *  is initialized very early (line 871), so `waitForMode` alone is not enough
+ *  to guarantee the listener exists. `_suppressHashWrite` flips to false either
+ *  via zoomWatcher init or at the end of the boot deep-link section (line 2734);
+ *  by the time it's false, the hashchange listener is definitely registered. */
+async function waitForBootSettled(page, timeoutMs = 180000) {
+  await page.waitForFunction(
+    async () => {
+      try {
+        const v = await window._ojs?.ojsConnector?.mainModule?.value('viewer');
+        return v?._suppressHashWrite === false;
+      } catch { return false; }
+    },
+    null,
+    { timeout: timeoutMs }
+  );
+}
+
+/** Wait until the URL hash's lat/lng (and optionally alt) match the expected
+ *  values within `eps` / `altEps`. Replaces fixed sleeps with a precise settle
+ *  condition for moveEnd-driven hash writes (regression for #205). */
+async function waitForHashLatLng(page, expectedLat, expectedLng, opts = {}) {
+  const eps = opts.eps ?? 0.001;
+  const expectedAlt = opts.alt ?? null;
+  const altEps = opts.altEps ?? 100;
+  const timeoutMs = opts.timeoutMs ?? 10000;
+  await page.waitForFunction(
+    ({ lat, lng, eps, alt, altEps }) => {
+      const params = new URLSearchParams(location.hash.slice(1));
+      const ul = parseFloat(params.get('lat'));
+      const un = parseFloat(params.get('lng'));
+      if (!Number.isFinite(ul) || !Number.isFinite(un)) return false;
+      if (Math.abs(ul - lat) >= eps || Math.abs(un - lng) >= eps) return false;
+      if (alt != null) {
+        const ua = parseFloat(params.get('alt'));
+        if (!Number.isFinite(ua) || Math.abs(ua - alt) >= altEps) return false;
+      }
+      return true;
+    },
+    { lat: expectedLat, lng: expectedLng, eps, alt: expectedAlt, altEps },
+    { timeout: timeoutMs }
+  );
+}
+
+/** Snapshot camera + mode + selection + URL hash from the live page.
+ *  `selectedPid` and `selectedH3` are intentionally read from `viewer._globeState`
+ *  — that's the canonical URL-selection backing state today. If a future refactor
+ *  renames or relocates these fields, this spec is the place to update. */
+async function snapshot(page) {
+  return await page.evaluate(async () => {
+    const v = await window._ojs?.ojsConnector?.mainModule?.value('viewer');
+    const carto = v?.camera?.positionCartographic;
+    if (!carto) return null;
+    return {
+      url: location.href,
+      hash: location.hash,
+      lat: Cesium.Math.toDegrees(carto.latitude),
+      lng: Cesium.Math.toDegrees(carto.longitude),
+      alt: carto.height,
+      mode: v._globeState.mode,
+      selectedPid: v._globeState.selectedPid || null,
+      selectedH3: v._globeState.selectedH3 || null,
+    };
+  });
+}
+
+
+// ---------------------------------------------------------------------------
+// From search-real-count.spec.js
+// ---------------------------------------------------------------------------
+
+/** Wait until the explorer has rendered the search input. Boot sequence:
+ *  phase1 (viewer + cluster cache) → facetFilters → search input wiring.
+ *  The input is in the DOM from page load but only functional after wiring. */
+async function waitForSearchReady(page, ms = 60000) {
+  await page.locator('#sampleSearch').first().waitFor({ timeout: ms });
+  await page.locator('#searchSubmitBtn').first().waitFor({ timeout: ms });
+  // The search results line is created at boot too — wait for the
+  // facetFilters cell to settle so a search fires against a populated
+  // facet UI (matches what a real user would experience).
+  await page.waitForFunction(
+    () => document.querySelectorAll('#materialFilterBody input[type="checkbox"]').length > 0,
+    null, { timeout: ms }
+  );
+}
+
+/** Collect `isamples.search` JSON payloads from the console (matches the
+ *  pattern used in tests/test_search_perf.py:204). */
+function attachSearchLogCollector(page) {
+  const captured = [];
+  page.on('console', (msg) => {
+    if (msg.type() !== 'log') return;
+    const text = msg.text();
+    if (!text.includes('isamples.search')) return;
+    try {
+      const payload = JSON.parse(text);
+      if (payload?.event === 'isamples.search') captured.push(payload);
+    } catch { /* not a structured search log */ }
+  });
+  return captured;
+}
+
+async function runSearch(page, term) {
+  // Quarto's see-also rendering produces a duplicate #sampleSearch in the
+  // DOM; `document.getElementById` (which the live JS uses) resolves to
+  // the FIRST instance, so the test mirrors that with `.first()`.
+  const input = page.locator('#sampleSearch').first();
+  await input.click();
+  await input.press('ControlOrMeta+a');
+  await input.press('Delete');
+  await input.fill(term);
+  await page.locator('#searchSubmitBtn').first().click();
+}
+
+// ---------------------------------------------------------------------------
+// NEW helpers (not in any existing spec)
+// ---------------------------------------------------------------------------
+
+/** Read the current value of 'window.__searchFilter'.
+ *  Returns the filter object '{ active, term, token, total, kind }' or null. */
+async function getSearchFilter(page) {
+  return page.evaluate(() => window.__searchFilter);
+}
+
+/** Read 'viewer._globeState.selectedPid' via the OJS mainModule 'viewer' value.
+ *  Returns the PID string, or null if none is selected. */
+async function getSelectedPid(page) {
+  return page.evaluate(async () => {
+    try {
+      const v = await window._ojs?.ojsConnector?.mainModule?.value('viewer');
+      return v?._globeState?.selectedPid || null;
+    } catch { return null; }
+  });
+}
+
+module.exports = {
+  waitForBootReady,
+  waitForFacetUI,
+  waitForFacetCountsStable,
+  readFacetCounts,
+  heatmapState,
+  markerVisibility,
+  waitForMode,
+  snapshot,
+  waitForSearchReady,
+  runSearch,
+  getSearchFilter,
+  getSelectedPid,
+};


### PR DESCRIPTION
## #249 PR2 — Characterization tests (the refactor safety net)

Adds browser-level characterization tests that pin the explorer behaviors **before** any `explorer.qmd` logic moves in PR3+. Additive only — no production code changed; the PR-blocking smoke gate (`explorer-smoke`) is unchanged. These run via `workflow_dispatch` (they depend on slow live-parquet loads).

**Files:** `tests/playwright/helpers/explorer.js` (consolidated helpers), `tests/playwright/explorer-characterization.spec.js` (7 tests), `tests/README.md`.

**Coverage** (Codex's 6 named gaps; heatmap already covered by `heatmap-overlay.spec.js`):
- (a+) search scopes the table to the matching record (deterministic single-result)
- (a-) clear removes the filter
- (b) material facet strictly decreases the table total
- (d1) `?search=` deep-link restores state **and** propagates to `#tableMeta`
- (d2) `&pid=` deep-link restores `selectedPid` + renders `#clusterSection`
- (e) facet hydration (source counts, material URIs, no stuck `.recomputing`)
- (f) known sample → `#inMapCard` with **exact** material

**Verification:** all 7 pass against live 202608 (independently run). Codex MERGE (3 review rounds: initial → tightened all 5 false-pass/mislabel findings → final clean).

**Two real behavior gaps surfaced (→ follow-up issues, not blockers):**
1. `&pid=` deep-link sets `selectedPid` + sample card but does **not** open `#inMapCard` (row-click does) — UX inconsistency (#239-family)
2. Clearing a search resets the table to the **global** total, losing viewport scoping

🤖 Generated with [Claude Code](https://claude.com/claude-code)
