### PR TITLE
#281/#282 Half(a): facet hierarchy data pipeline (tree + membership + counts)

### DIFF
--- a/FACET_HIERARCHY_PLAN.md
+++ b/FACET_HIERARCHY_PLAN.md
@@ -1,0 +1,252 @@
+# Facet hierarchy plan — tree display of facet values (#281 + #282)
+
+Draft for Codex + RY review (2026-06-17). Issues:
+- **#281** (ekansa): show facet hierarchy in a tree, first two levels unfolded, click to open deeper.
+- **#282** (akthom): nested + alphabetical across all three concept vocabularies.
+- **#276**: the counting-semantics fork this forces — single "first non-root" value vs **membership** ("anywhere in the path").
+
+Treated as **one design**. This is the biggest explorer UI change since launch; it
+rides on the #249 test net (PR1/PR2 merged; PR3 deployed; PR4a/PR4b/#285 in flight).
+
+---
+
+## 0. What I verified first (grounding — don't trust the folklore)
+
+The Slack/issue framing was "the data already carries each sample's full vocab
+ancestry, so the tree is in hand." **That is only half true** — verified against
+code + the live 202608 data, not assumed:
+
+1. **The facet UI is entirely flat today.** `explorer.qmd` `facetFilters` cell
+   (L1783–1873) renders material/context/object_type as a flat checkbox list via
+   `renderFilter()` (L1843), sorted by `count DESC` from `facet_summaries`. Source
+   is hard-coded flat HTML (L659–690). No parent/child/tree/indent anywhere.
+   `vocab_labels` is loaded only as `uri → pref_label` (no `broader`).
+
+2. **`sample_facets_v3` is one row per `pid` with a SINGLE already-flattened URI
+   per dimension.** `build_frontend_derived.py` picks the **first non-root**
+   material concept per sample (`arg_min(ic.uri, ord)` over the wide array,
+   excluding `MATERIAL_ROOT`, L86–96); context/object_type take array element
+   `[1]` and their root-dropping is still deferred (L29–30, L114–115).
+
+3. **The wide arrays are a SET of asserted concepts, NOT a clean ancestry path.**
+   Real 202608 data — one sample's `p__has_material_category` resolves (in array
+   order) to: `mineral`, `material` (root), `rock`. The canonical SKOS tree is
+   `mineral → earthmaterial → material` and `rock → rockorsediment → earthmaterial
+   → material`. So the array `{mineral, material, rock}` is **neither** a path
+   **nor** a transitive closure (it's missing `earthmaterial` and `rockorsediment`,
+   and spans two branches). Array-length distribution: len 1 = 6,233,867 samples,
+   len 2 = 1,601, len 3 = 491,424.
+
+   **Consequence:** full transitive ancestry must be **computed at build time** by
+   walking `skos:broader` from each asserted concept to the root. We cannot read
+   it straight off the array.
+
+4. **The canonical tree IS available** — `build_vocab_labels.py` already fetches
+   ~12 SKOS TTLs (core material/sampledfeature/objecttype + OpenContext, earthenv,
+   biology extensions) but **drops** `skos:broader` from its output. The three
+   core vocabularies are small and shallow:
+
+   | vocab | concepts (core) | root | max depth | level-1 children |
+   |---|---|---|---|---|
+   | material | 21 | `material` | 3 | 7 |
+   | sampledfeature | 20 | `anysampledfeature` | 3 | 4 |
+   | objecttype | 20 | `materialsample` | 3 | 5 |
+
+   Extension TTLs add more nodes under these roots, but the structure stays
+   shallow. "First two levels unfolded" reveals most of each tree.
+
+**Net:** the tree is *derivable* but not free. Two build-time additions are
+needed — (a) emit the `broader` edges, (b) compute per-sample membership over the
+ancestry. The UI then renders the tree and counts/filters via membership.
+
+---
+
+## 1. Two halves, two dependency profiles
+
+| Half | What | Depends on #249 refactor? |
+|---|---|---|
+| **(a) Data/pipeline** | tree edges + membership-count derived files | **No** — pure backend; can start now |
+| **(b) Tree UI** | tree rendering + membership filtering in `explorer.qmd` | **Yes** — touches the facet cells PR4b/#285 also touch |
+
+So we break ground on **(a) immediately**; **(b)** lands after PR4a/PR4b/#285 merge.
+
+---
+
+## 2. Half (a) — data/pipeline (start now)
+
+### 2.1 Emit the tree (`build_vocab_labels.py`)
+Add a `broader` column (parent URI, nullable for roots) to `vocab_labels.parquet`,
+read from `skos:broader` across **all** the TTLs already parsed. Optionally also a
+`depth` (int, root = 0) and `scheme` (already present). Validation: every non-root
+concept resolves to a root via `broader`; no cycles; every `facet_value` that
+appears in the data has a tree node (flag orphans — these are the #161/#148-style
+label-gap cousins).
+
+### 2.2 Compute membership (`build_frontend_derived.py`)
+New derived table, one row per (sample, concept-in-its-ancestry):
+```
+sample_facet_membership(pid, facet_type, concept_uri, depth)
+```
+For each sample and each dimension: take the asserted concept(s) from the wide
+array, drop the bare root, and for each, walk `broader` to the root emitting a row
+per ancestor (dedup per pid×concept). A sample tagged `{mineral, rock}` → membership
+`{mineral, earthmaterial, rockorsediment, rock, material?}` (root-inclusion = open
+question Q2). This is **membership semantics** (#276 "anywhere in the path").
+
+Then hierarchical counts come from a GROUP BY on the membership table:
+```
+facet_tree_summaries(facet_type, concept_uri, parent_uri, depth, label, count)
+  where count = COUNT(DISTINCT pid) with that concept in its membership set
+```
+**Counting invariant (Codex-corrected):** counts are a **distinct-pid UNION**, NOT
+additive. `parent_count = COUNT(DISTINCT pid)` over (direct ∪ all descendants); the
+only guaranteed relation is `parent_count >= every child_count`. Do **not** assert
+`parent = direct + Σ children` — a `{mineral, rock}` sample lands under multiple
+sibling branches, so children overlap. (Verified both directions on real data — see §7.)
+
+**Universe must match the explorer (Codex):** build membership from the **located**
+sample set (`samp_geo` — `MaterialSampleRecord` with geometry), the same universe the
+map/table/existing facet_summaries use, or hierarchy counts will drift from every
+other surface.
+
+**URI form is first-class (Codex):** the SKOS TTLs use *un-versioned* URIs
+(`.../material/anthropogenicmetal`) while the data uses *versioned* ones
+(`.../material/1.0/rock`). `broader` edges MUST be emitted in the **data form** —
+reuse the alias/version normalization `build_vocab_labels.py` already applies
+(its data-form aliases exist for exactly this reason). Verified: a naive join is
+0% match; with version-segment normalization it's correct (§7).
+
+**SKOS is a DAG, not a tree (Codex):** 29 concepts across the loaded vocabularies
+have multiple `skos:broader` parents. The validator must either pick a canonical
+parent deterministically or define multi-parent rendering before UI work; don't
+silently assume a single-parent tree.
+
+### 2.3 Sizing / perf
+Membership ≈ samples × avg ancestry depth. With depth ≤ 3–4 and most samples at
+len 1, expect ~15–25M rows over 6.7M samples (vs `facets_v3` 6.7M rows). Store
+sorted by `(facet_type, pid)` for the bbox-JOIN path; ZSTD. **Validate query
+latency** (the explorer reads these over HTTP range requests) before committing to
+the shape — mirror `profile_queries.py`. If the per-pid membership table is too
+heavy for the viewport-scoped count JOIN, fall back to a precomputed
+`facet_tree_cross_filter` cube (like today's `facet_cross_filter`).
+
+### 2.4 Outputs, validator, publish
+- New/changed files (versioned, **non-cutover** — publish alongside, don't
+  overwrite prod): `…_facet_tree_summaries.parquet`, `…_sample_facet_membership.parquet`,
+  `vocab_labels_*.parquet` (+`broader`).
+- Extend `validate_frontend_derived.py`: tree integrity (single root per scheme,
+  no cycles, parent counts ≥ child counts and = direct+Σchildren), membership grain
+  (no dup pid×concept), label coverage.
+- Ship as a **data-pipeline-only PR** (no `explorer.qmd`). Prove counts in a notebook
+  / query log committed under the existing `*_SUMMARY` convention.
+
+---
+
+## 3. Half (b) — tree UI (after #249 PRs merge)
+
+### 3.1 Rendering
+Replace flat `renderFilter()` for material/context/object_type with a tree builder
+fed by `facet_tree_summaries` (parent_uri + depth + label + count). Source stays
+flat (no vocab tree). Behavior per #281/#282:
+- Render the tree **nested + alphabetical** within each level (#282).
+- **First two levels unfolded** (root's children + grandchildren); deeper nodes
+  collapsed behind a disclosure control; click to expand (#281).
+- Each node: checkbox + label + `(membership count)` in the existing
+  `.facet-count[data-facet][data-value]` span shape so the count-update plumbing
+  (`applyFacetCounts`, `.recomputing`) is reused unchanged.
+
+### 3.2 Counts
+`updateCrossFilteredCounts` reads membership counts instead of single-value counts.
+Node count = its membership count under the current viewport + cross-filter + search.
+Parent = direct + Σ descendants falls out of the membership GROUP BY.
+
+### 3.3 Filtering semantics (the coherence contract)
+Selecting a node filters to its **entire subtree** (membership): `facetFilterSQL`
+changes from `material IN (…)` on `facets_v3` to `pid IN (SELECT pid FROM membership
+WHERE concept_uri IN (selected nodes + their descendants))`. **Counts and the table
+filter must share one expression** (the `FACETS_DESCRIPTION_EXPR` discipline from
+the 202608 work / the #245 "facet == table" invariant), or legend and table drift.
+- Parent/child checkbox interaction: selecting a parent selects its subtree
+  (tri-state indeterminate for partial — **Q3**).
+
+### 3.4 Interactions to respect
+- `?material=` URL param (and friends) must accept tree nodes and round-trip
+  (cf. facet-viewport `coherence` test).
+- The #267 "active facet forces point mode" rule and the B1 viewport-scoped count
+  path (moveStart `.recomputing` → moveEnd `refreshFacetCounts`) stay intact.
+- Rides on the refactored facet code from #249 PR3 (`sql-builders.js`) — extend
+  there, with `node --test` units for the new tree/membership SQL builders.
+
+---
+
+## 4. Sequencing & gate
+1. **Now:** Half (a) — tree edges + membership + `facet_tree_summaries`, validator,
+   latency probe, notebook proof. Data-pipeline PR; publish versioned files.
+2. **After PR4a/PR4b/#285 merge:** Half (b) — tree UI + membership filtering, behind
+   the smoke + characterization + new tree-specific Playwright specs (assert
+   parent count = direct+Σchildren; selecting a parent filters the subtree; 2-levels
+   unfolded; legend == table under a subtree selection). Codex per step.
+3. Keep single-value `facets_v3` until (b) ships, then decide deprecate vs keep
+   (Q1).
+
+---
+
+## 5. Open questions (for Codex + RY)
+- **Q1 — migrate or coexist?** Does hierarchy fully replace the single-value
+  `facets_v3` columns (filtering + counts move to membership), or do both ship?
+  (Hierarchy needs membership for both; single-value can't express subtree filter.)
+- **Q2 — root inclusion.** Does membership include the bare root (`material`,
+  `anysampledfeature`, `materialsample`)? It's the "All" node; probably render it
+  as the tree root label, not a selectable facet — confirm.
+- **Q3 — parent selection UX.** Selecting a parent = select whole subtree, with a
+  tri-state indeterminate when only some children are checked? Or parent is a pure
+  filter (subtree) with no child checkboxes shown until expanded?
+- **Q4 — multi-asserted leaves.** A sample tagged `{mineral, rock}` contributes to
+  both branches' ancestries (union). Confirm that's the intended "membership"
+  reading (vs picking one). #276 leans union.
+- **Q5 — which dims first.** material is the #282 priority; sampledfeature +
+  objecttype follow the same machinery; source never gets a tree. Ship all three
+  trees at once or material-first?
+- **Q6 — count perf.** Is the per-pid membership JOIN viable for viewport-scoped
+  counts, or do we precompute a `facet_tree_cross_filter` cube? Decide from the
+  2.3 latency probe.
+
+---
+
+## 6. First concrete step — DONE (proof-of-concept)
+`scripts/poc_facet_hierarchy.py` builds the proof against the local 202608 wide +
+the SKOS TTLs: merges `broader` edges (per-file parse — a combined-graph parse
+silently drops material's edges), normalizes URIs to data form, computes the
+ancestor closure + membership, and checks the invariants. Run:
+`python scripts/poc_facet_hierarchy.py --wide <202608_wide.parquet> --ttls <dir>`.
+
+## 7. PoC results (proven, material dimension, 202608)
+- located samples = **6,026,242**; located-with-material = **5,829,436**;
+  membership = **15,076,893** rows.
+- **INVARIANT A — parent ≥ child: PASS** (counts monotonic down the tree).
+- **INVARIANT B — root == located-with-material: PASS** (5,829,436 = 5,829,436;
+  every located sample with a material concept reaches the root).
+- **INVARIANT C — non-additive: confirmed** (earthmaterial distinct = 4,091,133 ≠
+  Σ children = 2,028,538). Additive summing is wrong in both directions.
+- Sane tree: material 5.83M → earthmaterial 4.09M → rockorsediment 852K → rock 794K;
+  mineral 303K; organicmaterial 1.02M.
+- **Gotchas surfaced & fixed:** (1) URI version-form mismatch (0% join → fixed by
+  normalization); (2) rdflib drops material edges when many TTLs share one graph
+  (parse per-file, merge dicts); (3) 29 multi-parent (DAG) concepts exist.
+
+**Next:** wire this into `build_vocab_labels.py` (emit `broader`, data-form) +
+`build_frontend_derived.py` (closure + membership + `facet_tree_summaries`, built
+from `samp_geo`) + `validate_frontend_derived.py` (tree integrity, parent≥child,
+DAG policy), behind a latency probe. Ship as the data-only PR (Half a). Then Half b.
+
+## 8. Codex review — accepted corrections (2026-06-17, gpt-5.5)
+Verdict: "directionally sound." Accepted: (1) distinct-pid-union invariant, not
+additive [§2.2]; (2) build membership from the located universe [§2.2]; (3) URI-form
+normalization is first-class [§2.2]; (4) DAG/multi-parent handling [§2.2]; (5) extract
+a selected-facet **state model** (URL/checkbox/filter-SQL/cross-filter currently all
+read the DOM directly) rather than just nested HTML [§3]; (6) put membership SQL in
+`assets/js/sql-builders.js` with `node --test` units [§3]; (7) consider a
+**closure table** (`concept_closure(ancestor, descendant, distance)` + asserted
+projection) over a materialized membership file — benchmark both; (8) **ship
+material-first** behind shared machinery [§5 Q5]; (9) parent UX = store the parent
+URI + derive descendants, don't explode into the URL, tri-state indeterminate [§5 Q3].

--- a/scripts/build_frontend_derived.py
+++ b/scripts/build_frontend_derived.py
@@ -279,7 +279,10 @@ def build_concept_membership(con, wide, vocab_labels, t0):
         UNION ALL
         SELECT c.descendant, t.parent_uri AS ancestor, c.distance + 1
         FROM clo c JOIN concept_tree t ON t.uri = c.ancestor
-        WHERE t.parent_uri IS NOT NULL
+        -- Cycle guard (Codex r2): the SKOS projection is acyclic today, but cap
+        -- depth so a future bad vocab (a broader cycle) can't recurse forever.
+        -- 64 >> any real concept depth (live max is 3).
+        WHERE t.parent_uri IS NOT NULL AND c.distance < 64
       )
       SELECT DISTINCT descendant, ancestor, distance FROM clo;
     """)

--- a/scripts/build_frontend_derived.py
+++ b/scripts/build_frontend_derived.py
@@ -44,9 +44,26 @@ import duckdb
 
 MATERIAL_ROOT = "https://w3id.org/isample/vocabulary/material/1.0/material"
 FACET_DIMS = ["source", "material", "context", "object_type"]
+# Hierarchical dims (#281/#282): wide array column + the dim's canonical SKOS
+# root. The array carries each sample's SET of asserted IdentifiedConcept
+# row_ids (general↔specific, no guaranteed order — FACET_HIERARCHY_PLAN.md §0).
+# The root is dropped from "asserted" (re-added via closure) and is the single
+# tree root per dim. source has no vocab tree. (Codex: drop ONLY these explicit
+# roots, not every parentless concept — deprecated/parentless concepts must stay.)
+DIM_ARRAY_COL = {
+    "material": "p__has_material_category",
+    "context": "p__has_context_category",
+    "object_type": "p__has_sample_object_type",
+}
+DIM_ROOT = {
+    "material": MATERIAL_ROOT,
+    "context": "https://w3id.org/isample/vocabulary/sampledfeature/1.0/anysampledfeature",
+    "object_type": "https://w3id.org/isample/vocabulary/materialsampleobjecttype/1.0/materialsample",
+}
 # the artifacts this script knows how to build (for --only/--skip validation)
 ARTIFACTS = ["sample_facets_v2", "samples_map_lite", "h3_summaries",
-             "facet_summaries", "facet_cross_filter", "wide_h3"]
+             "facet_summaries", "facet_cross_filter", "wide_h3",
+             "sample_facet_membership", "facet_tree_summaries"]
 
 
 def log(msg, t0):
@@ -234,6 +251,114 @@ def build_wide_h3(con, wide, out):
     ) TO '{out}' (FORMAT PARQUET, COMPRESSION ZSTD)""")
 
 
+def build_concept_membership(con, wide, vocab_labels, t0):
+    """Build the hierarchy temp tables (#281/#282/#276) from vocab_labels' data-form
+    `broader` edges + the wide concept arrays, over the LOCATED universe (samp_geo)
+    so counts match the map/table. Creates: concept_tree, concept_closure, roots,
+    asserted, membership. See FACET_HIERARCHY_PLAN.md §2."""
+    # concept_tree: data-form (uri, canonical primary parent, depth-from-root).
+    # vocab_labels already aliases broader into data form, so this joins to the
+    # data-form concept URIs the wide arrays resolve to.
+    con.execute(f"""
+    CREATE OR REPLACE TEMP TABLE vl_edges AS
+      SELECT DISTINCT uri, broader AS parent_uri
+      FROM read_parquet('{vocab_labels}') WHERE uri_form='data_v1';
+    CREATE OR REPLACE TEMP TABLE concept_tree AS
+      WITH RECURSIVE depths AS (
+        SELECT uri, parent_uri, 0 AS depth FROM vl_edges WHERE parent_uri IS NULL
+        UNION ALL
+        SELECT e.uri, e.parent_uri, d.depth + 1
+        FROM vl_edges e JOIN depths d ON e.parent_uri = d.uri
+      )
+      SELECT uri, ANY_VALUE(parent_uri) AS parent_uri, MIN(depth) AS depth
+      FROM depths GROUP BY uri;
+    -- transitive ancestor closure (self at distance 0)
+    CREATE OR REPLACE TEMP TABLE concept_closure AS
+      WITH RECURSIVE clo AS (
+        SELECT uri AS descendant, uri AS ancestor, 0 AS distance FROM concept_tree
+        UNION ALL
+        SELECT c.descendant, t.parent_uri AS ancestor, c.distance + 1
+        FROM clo c JOIN concept_tree t ON t.uri = c.ancestor
+        WHERE t.parent_uri IS NOT NULL
+      )
+      SELECT DISTINCT descendant, ancestor, distance FROM clo;
+    """)
+    # node_dim: assign each tree concept to the dim whose canonical root it reaches
+    # via the closure. This both (a) restricts the hierarchy to each dim's real
+    # tree and (b) keeps exactly one root per dim — deprecated/parentless concepts
+    # that don't reach a dim root are NOT treated as roots (Codex HIGH-1).
+    dim_root_vals = ", ".join(f"('{dim}', '{root}')" for dim, root in DIM_ROOT.items())
+    con.execute(f"""
+    CREATE OR REPLACE TEMP TABLE dim_root(facet_type VARCHAR, root_uri VARCHAR);
+    INSERT INTO dim_root VALUES {dim_root_vals};
+    CREATE OR REPLACE TEMP TABLE node_dim AS
+      SELECT DISTINCT c.descendant AS uri, r.facet_type
+      FROM concept_closure c JOIN dim_root r ON r.root_uri = c.ancestor;
+    """)
+    # asserted: every located sample's concept(s) per hierarchical dim, from the
+    # FULL wide array (not the flattened first-non-root value), dropping ONLY that
+    # dim's explicit root.
+    union = " UNION ALL ".join(
+        f"""SELECT DISTINCT sg.pid, '{dim}' AS facet_type, ic.uri AS concept
+            FROM samp_geo sg
+            JOIN read_parquet('{wide}') s ON s.pid = sg.pid,
+                 UNNEST(s.{col}) AS u(rid)
+            JOIN ic ON ic.row_id = u.rid
+            WHERE ic.uri <> '{DIM_ROOT[dim]}'"""
+        for dim, col in DIM_ARRAY_COL.items())
+    con.execute(f"CREATE OR REPLACE TEMP TABLE asserted AS {union};")
+    # membership: each asserted concept expanded to its ancestor closure, RESTRICTED
+    # to ancestors in the SAME dim's canonical tree. Membership semantics (#276): a
+    # sample counts under every node on the path(s) of every concept it asserts.
+    # Asserted concepts that don't reach their dim root (label gaps #148/#161, or
+    # the un-linked specimentype scheme) produce no rows → EXCLUDED from the
+    # hierarchy (flat facet_summaries still counts them) and reported below.
+    con.execute("""
+    CREATE OR REPLACE TEMP TABLE membership AS
+      SELECT DISTINCT a.pid, a.facet_type, c.ancestor AS concept_uri
+      FROM asserted a
+      JOIN concept_closure c ON c.descendant = a.concept
+      JOIN node_dim nd ON nd.uri = c.ancestor AND nd.facet_type = a.facet_type;
+    """)
+    n_tree = con.sql("SELECT COUNT(*) FROM concept_tree").fetchone()[0]
+    n_mem = con.sql("SELECT COUNT(*) FROM membership").fetchone()[0]
+    # Excluded = distinct (dim, concept) asserted that never reach the dim root.
+    excl = con.sql("""
+        SELECT a.facet_type, COUNT(DISTINCT a.concept) AS n
+        FROM asserted a
+        WHERE NOT EXISTS (
+          SELECT 1 FROM concept_closure c JOIN node_dim nd
+            ON nd.uri = c.ancestor AND nd.facet_type = a.facet_type
+          WHERE c.descendant = a.concept)
+        GROUP BY a.facet_type ORDER BY a.facet_type""").fetchall()
+    log(f"concept_tree={n_tree:,}  membership={n_mem:,}", t0)
+    if excl:
+        detail = ", ".join(f"{ft}={n}" for ft, n in excl)
+        log(f"NOTE: concepts EXCLUDED from hierarchy (no path to dim root; label "
+            f"gaps #148/#161 / un-linked schemes — flat facet_summaries still counts them): {detail}", t0)
+
+
+def build_sample_facet_membership(con, out):
+    con.execute(f"""COPY (
+        SELECT m.pid, m.facet_type, m.concept_uri, t.depth
+        FROM membership m JOIN concept_tree t ON t.uri = m.concept_uri
+        ORDER BY m.facet_type, m.pid, m.concept_uri
+    ) TO '{out}' (FORMAT PARQUET, COMPRESSION ZSTD)""")
+
+
+def build_facet_tree_summaries(con, out):
+    # Hierarchical counts: COUNT(DISTINCT pid) per node (membership = direct ∪
+    # descendants). NOT additive — a sample under two sibling branches counts
+    # once at each and once at their shared ancestor (FACET_HIERARCHY_PLAN.md §2.2).
+    con.execute(f"""COPY (
+        SELECT m.facet_type, m.concept_uri, t.parent_uri, t.depth,
+               COUNT(DISTINCT m.pid) AS count
+        FROM membership m JOIN concept_tree t ON t.uri = m.concept_uri
+        GROUP BY m.facet_type, m.concept_uri, t.parent_uri, t.depth
+        ORDER BY m.facet_type, count DESC, m.concept_uri
+    ) TO '{out}' (FORMAT PARQUET, COMPRESSION ZSTD)""")
+
+
 def file_meta(con, path):
     n = con.sql(f"SELECT COUNT(*) FROM read_parquet('{path}')").fetchone()[0]
     schema = [(r[0], r[1]) for r in con.sql(f"DESCRIBE SELECT * FROM read_parquet('{path}')").fetchall()]
@@ -256,6 +381,9 @@ def main():
     ap.add_argument("--tag", required=True, help="output prefix, e.g. isamples_202606 (no stale default)")
     ap.add_argument("--only", default="", help=f"comma list of: {','.join(ARTIFACTS)}")
     ap.add_argument("--skip", default="", help="comma list of the same names to skip")
+    ap.add_argument("--vocab-labels", default="",
+                    help="vocab_labels parquet (with `broader`, data_v1 rows) — "
+                         "required for sample_facet_membership / facet_tree_summaries (#281/#282)")
     ap.add_argument("--no-manifest", action="store_true", help="skip writing {tag}_manifest.json")
     ap.add_argument("--threads", type=int, default=0,
                     help="DuckDB thread count; set 1 for bit-stable floating centroids (slower)")
@@ -292,6 +420,20 @@ def main():
             build_h3_summary(con, p(f"h3_summary_res{res}"), res); produced.append(p(f"h3_summary_res{res}"))
         log("h3_summary_res{4,6,8} ✓", t0)
     emit("wide_h3", lambda o: build_wide_h3(con, args.wide, o))
+
+    # Hierarchy artifacts (#281/#282) — need vocab_labels for the SKOS tree.
+    if want("sample_facet_membership") or want("facet_tree_summaries"):
+        if not args.vocab_labels:
+            # Fail loud if the user EXPLICITLY asked for a hierarchy artifact
+            # (Codex) — silently skipping an explicit --only target is wrong.
+            explicit = only & {"sample_facet_membership", "facet_tree_summaries"}
+            if explicit:
+                sys.exit(f"FATAL: --only {sorted(explicit)} requires --vocab-labels <vocab_labels.parquet>")
+            log("SKIP hierarchy artifacts: pass --vocab-labels <vocab_labels.parquet>", t0)
+        else:
+            build_concept_membership(con, args.wide, args.vocab_labels, t0)
+            emit("sample_facet_membership", lambda o: build_sample_facet_membership(con, o))
+            emit("facet_tree_summaries", lambda o: build_facet_tree_summaries(con, o))
 
     if not args.no_manifest:
         log("hashing inputs/outputs for manifest…", t0)

--- a/scripts/build_vocab_labels.py
+++ b/scripts/build_vocab_labels.py
@@ -179,6 +179,14 @@ def extract_rows(ttl_url: str) -> list[dict]:
         scheme = _pick_scheme(g, c)
         definition = _pick_definition(g, c)
         alt_labels = sorted({str(a) for a in g.objects(c, SKOS.altLabel)})
+        # skos:broader parent (#281/#282 tree). SKOS permits multiple parents
+        # (a DAG); pick the lexicographically-first as the canonical primary so
+        # the column is deterministic, and stash the full set for the validator
+        # to flag multi-parent concepts. Vocab-form here; aliased to data-form
+        # in _emit_data_form_aliases so uri↔broader join within each uri_form.
+        broaders = sorted(str(b) for b in g.objects(c, SKOS.broader))
+        broader_vocab = broaders[0] if broaders else None
+        broader_count = len(broaders)
 
         # One row per language of skos:prefLabel; fall back to rdfs:label.
         pref_labels = list(g.objects(c, SKOS.prefLabel))
@@ -190,11 +198,14 @@ def extract_rows(ttl_url: str) -> list[dict]:
             # downstream JOINs at least know the URI exists.
             rows.append({
                 "uri": uri,
+                "uri_form": "vocab",
                 "pref_label": None,
                 "lang": None,
                 "scheme": scheme,
                 "definition": definition,
                 "alt_labels": alt_labels,
+                "broader": broader_vocab,
+                "broader_count": broader_count,
                 "source_ttl": ttl_url,
             })
             continue
@@ -208,6 +219,8 @@ def extract_rows(ttl_url: str) -> list[dict]:
                 "scheme": scheme,
                 "definition": definition,
                 "alt_labels": alt_labels,
+                "broader": broader_vocab,
+                "broader_count": broader_count,
                 "source_ttl": ttl_url,
             })
     return rows
@@ -254,6 +267,15 @@ def _emit_data_form_aliases(rows: list[dict]) -> list[dict]:
             clone = dict(r)
             clone["uri"] = data_uri
             clone["uri_form"] = "data_v1"
+            # Map the parent to its data form too, so a data_v1 row's `broader`
+            # joins to another data_v1 row's `uri` (same alias space). If the
+            # parent has no known data-form alias, leave the vocab-form parent
+            # (the validator flags any broader that resolves to no node).
+            parent = r.get("broader")
+            if parent:
+                parent_data = _data_form_uris(parent)
+                if parent_data:
+                    clone["broader"] = parent_data[0]
             aliases.append(clone)
     return aliases
 
@@ -320,6 +342,8 @@ def main(argv: list[str] | None = None) -> int:
             "scheme": scheme,
             "definition": None,
             "alt_labels": [],
+            "broader": None,          # deprecated leaf concepts; no tree parent
+            "broader_count": 0,
             "source_ttl": "manual_override",
         })
     print(f"  {len(MANUAL_LABEL_OVERRIDES):>4} rows  (manual overrides for deprecated URIs)")
@@ -343,6 +367,12 @@ def main(argv: list[str] | None = None) -> int:
     df.to_parquet(args.output, index=False)
     print(f"\nWrote {len(df):,} rows → {args.output}")
     print(f"  by uri_form: {df['uri_form'].value_counts().to_dict()}")
+    # Surface the SKOS DAG (#281/#282): concepts with >1 skos:broader parent.
+    # We keep the lexicographically-first as the canonical `broader` (a lossy
+    # tree projection); flag the count so the hierarchy build/UI can account for it.
+    if "broader_count" in df.columns:
+        multi = df[(df["uri_form"] == "vocab") & (df["broader_count"].fillna(0) > 1)]["uri"].nunique()
+        print(f"  multi-parent (DAG) concepts: {multi} (canonical primary parent kept; lossy projection)")
     print(f"  unique URIs: {df['uri'].nunique():,}")
     print(f"  languages:   {sorted(df['lang'].dropna().unique().tolist())}")
     print(f"  schemes:     {df['scheme'].nunique()} distinct skos:inScheme values")

--- a/scripts/poc_facet_hierarchy.py
+++ b/scripts/poc_facet_hierarchy.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Proof-of-concept for the facet hierarchy plan (#281/#282/#276) — Half (a).
+
+De-risks the data/pipeline half BEFORE touching build_vocab_labels.py /
+build_frontend_derived.py: derive the concept tree from SKOS `broader`, compute
+per-sample membership over the ancestry, aggregate hierarchical counts, and check
+the invariants. See FACET_HIERARCHY_PLAN.md §6/§7.
+
+Material dimension only (the #282 priority); the same machinery generalizes to
+context (sampledfeature) and object_type.
+
+Gotchas this encodes (all surfaced empirically):
+  1. URI form: SKOS TTLs use un-versioned URIs (.../material/rock) but the data
+     uses versioned ones (.../material/1.0/rock). We normalize by stripping the
+     /X.Y/ version segment so the ancestry join matches. (Production reuses
+     build_vocab_labels.py's alias/version logic instead.)
+  2. rdflib drops material's broader edges when many TTLs are parsed into ONE
+     graph — parse each TTL into its own graph and merge the dicts.
+  3. SKOS is a DAG: some concepts have multiple skos:broader parents.
+
+Counting invariant (Codex-corrected): counts are a distinct-pid UNION, NOT
+additive. parent_count = COUNT(DISTINCT pid over direct ∪ descendants); only
+parent_count >= every child_count is guaranteed.
+
+Usage:
+  python scripts/poc_facet_hierarchy.py --wide /path/202608_wide.parquet \
+      --ttls /path/to/ttl_dir
+"""
+import argparse
+import glob
+import re
+
+import duckdb
+import rdflib
+from rdflib.namespace import SKOS
+
+VERSION_SEG = re.compile(r"/\d+\.\d+(?=/)")  # the "/1.0" version path segment
+MATERIAL_ROOT_NORM = "https://w3id.org/isample/vocabulary/material/material"
+
+
+def norm(uri):
+    """Strip the version segment so TTL (un-versioned) and data (versioned) URIs join."""
+    return VERSION_SEG.sub("", uri) if uri else uri
+
+
+def load_broader(ttl_dir):
+    """Merge skos:broader across all TTLs. Parse each file into its OWN graph —
+    a single shared graph silently drops material's edges."""
+    broader, multi = {}, {}
+    for f in sorted(glob.glob(f"{ttl_dir}/*.ttl")):
+        g = rdflib.Graph().parse(f, format="turtle")
+        for s, _, o in g.triples((None, SKOS.broader, None)):
+            cs, co = norm(str(s)), norm(str(o))
+            broader.setdefault(cs, co)
+            multi.setdefault(cs, set()).add(co)
+    dag = {k: v for k, v in multi.items() if len(v) > 1}
+    return broader, dag
+
+
+def ancestor_closure(broader):
+    """Return [(descendant, ancestor, distance)] including self at distance 0."""
+    def chain(u):
+        out, seen, cur, d = [(u, 0)], {u}, u, 0
+        while cur in broader and broader[cur] not in seen:
+            cur = broader[cur]; d += 1; out.append((cur, d)); seen.add(cur)
+        return out
+    concepts = set(broader) | set(broader.values())
+    return [(c, a, d) for c in concepts for (a, d) in chain(c)]
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--wide", required=True, help="202608 wide parquet")
+    ap.add_argument("--ttls", required=True, help="dir of SKOS .ttl vocab files")
+    args = ap.parse_args()
+
+    broader, dag = load_broader(args.ttls)
+    print(f"broader edges: {len(broader)}   multi-parent (DAG) concepts: {len(dag)}")
+    closure = ancestor_closure(broader)
+
+    con = duckdb.connect()
+    con.create_function("norm", norm, ["VARCHAR"], "VARCHAR")
+    con.execute("CREATE TABLE closure(descendant VARCHAR, ancestor VARCHAR, distance INT)")
+    con.executemany("INSERT INTO closure VALUES (?,?,?)", closure)
+    con.execute("CREATE TABLE parent(child VARCHAR, parent VARCHAR)")
+    con.executemany("INSERT INTO parent VALUES (?,?)", list(broader.items()))
+
+    w = args.wide
+    con.execute(f"""
+    CREATE TEMP TABLE ic AS
+      SELECT row_id, pid AS uri FROM read_parquet('{w}') WHERE otype='IdentifiedConcept';
+    -- LOCATED universe = the explorer's universe (samp_geo): MaterialSampleRecord w/ geometry
+    CREATE TEMP TABLE located AS
+      SELECT pid FROM read_parquet('{w}') WHERE otype='MaterialSampleRecord' AND geometry IS NOT NULL;
+    CREATE TEMP TABLE asserted AS
+      SELECT DISTINCT s.pid, norm(ic.uri) AS concept
+      FROM read_parquet('{w}') s JOIN located l ON l.pid = s.pid,
+           UNNEST(s.p__has_material_category) AS u(rid) JOIN ic ON ic.row_id = u.rid
+      WHERE s.otype='MaterialSampleRecord' AND norm(ic.uri) <> '{MATERIAL_ROOT_NORM}';
+    CREATE TEMP TABLE membership AS
+      SELECT DISTINCT a.pid, c.ancestor AS concept
+      FROM asserted a JOIN closure c ON c.descendant = a.concept;
+    CREATE TEMP TABLE tree_counts AS
+      SELECT concept, COUNT(DISTINCT pid) AS cnt FROM membership GROUP BY concept;
+    """)
+
+    n_loc = con.sql("SELECT COUNT(*) FROM located").fetchone()[0]
+    n_wm = con.sql("SELECT COUNT(DISTINCT pid) FROM asserted").fetchone()[0]
+    n_mem = con.sql("SELECT COUNT(*) FROM membership").fetchone()[0]
+    print(f"located={n_loc:,}  located-with-material={n_wm:,}  membership rows={n_mem:,}")
+
+    bad = con.sql("""
+        SELECT p.parent, p.child, pc.cnt, cc.cnt FROM parent p
+        JOIN tree_counts pc ON pc.concept=p.parent
+        JOIN tree_counts cc ON cc.concept=p.child WHERE cc.cnt > pc.cnt""").fetchall()
+    print(f"INVARIANT A (parent>=child): {'PASS' if not bad else 'FAIL ' + str(bad[:3])}")
+
+    root = con.sql(f"SELECT cnt FROM tree_counts WHERE concept='{MATERIAL_ROOT_NORM}'").fetchone()
+    root = root[0] if root else 0
+    print(f"INVARIANT B (root==located-with-material): root={root:,} expected={n_wm:,} "
+          f"{'PASS' if root == n_wm else 'DIFF'}")
+
+    tail = lambda u: u.rsplit("/", 1)[-1]
+    print("\n=== material membership counts (located samples) ===")
+    for c, cnt in con.sql(
+        "SELECT concept, cnt FROM tree_counts WHERE concept LIKE '%/material/%' "
+        "ORDER BY cnt DESC LIMIT 14").fetchall():
+        p = broader.get(c)
+        print(f"  {cnt:>10,}  {tail(c):26s} (parent: {tail(p) if p else 'ROOT'})")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate_frontend_derived.py
+++ b/scripts/validate_frontend_derived.py
@@ -310,6 +310,12 @@ def main():
               f"{dims_present} dims present (want material/context/object_type)")
         # CROSS-FILE ALGEBRA: material root membership == facets_v2 non-root material
         # (both = located samples carrying ≥1 non-root material concept).
+        # NOTE (Codex r2): this equality holds under the current-data invariant
+        # "0 material concepts excluded from the hierarchy" (every located
+        # material concept resolves to the material tree). If a future vintage
+        # introduces a material concept absent from the SKOS tree, facets_v2 would
+        # still count it flat while the hierarchy excludes it, and this check would
+        # (correctly) fail — revisit the equality then.
         mat_root = scalar(f"SELECT count FROM {T} WHERE facet_type='material' AND parent_uri IS NULL")
         fv2_mat = scalar(f"SELECT COUNT(*) FROM {F} WHERE material IS NOT NULL")
         check("tree: material root == facets_v2 non-root material count",

--- a/scripts/validate_frontend_derived.py
+++ b/scripts/validate_frontend_derived.py
@@ -50,6 +50,8 @@ def main():
     ap.add_argument("--facets"); ap.add_argument("--map-lite")
     ap.add_argument("--summaries"); ap.add_argument("--cross-filter")
     ap.add_argument("--h3", nargs=3, metavar=("R4", "R6", "R8"))
+    ap.add_argument("--tree-summaries", help="facet_tree_summaries parquet (#281/#282); optional")
+    ap.add_argument("--membership", help="sample_facet_membership parquet (#281/#282); optional")
     ap.add_argument("--wide", help="source wide parquet — enables the SEMANTIC gate "
                     "(re-derive and diff the written files against a fresh build)")
     ap.add_argument("--min-rows", type=int, default=1_000_000,
@@ -274,6 +276,57 @@ def main():
                       ("object_type", "https://w3id.org/isample/vocabulary/materialsampleobjecttype/1.0/materialsample")]:
         n = scalar(f"SELECT COUNT(*) FROM {F} WHERE {dim}='{root}'")
         info.append(f"{dim} root-concept rows: {n:,} (informational; root-dropping deferred)")
+
+    # --- hierarchy artifacts (#281/#282) — checked only when present ---
+    def _opt(name, attr):
+        v = getattr(a, attr)
+        if v:
+            return v
+        if a.dir and a.tag:
+            p = os.path.join(a.dir, f"{a.tag}_{name}.parquet")
+            return p if os.path.exists(p) else None
+        return None
+    tree = _opt("facet_tree_summaries", "tree_summaries")
+    mem = _opt("sample_facet_membership", "membership")
+    if tree:
+        T = f"read_parquet('{tree}')"
+        # parent ≥ child for every edge, every dim (distinct-pid UNION semantics —
+        # NOT additive; see FACET_HIERARCHY_PLAN.md §2.2).
+        viol = scalar(f"""SELECT COUNT(*) FROM {T} c JOIN {T} p
+            ON p.concept_uri=c.parent_uri AND p.facet_type=c.facet_type
+            WHERE c.count > p.count""")
+        check("tree: parent count >= every child count", viol == 0, f"{viol} edges violate")
+        # every non-null parent_uri resolves to a node (no dangling edges)
+        orph = scalar(f"""SELECT COUNT(*) FROM {T} c WHERE c.parent_uri IS NOT NULL
+            AND NOT EXISTS (SELECT 1 FROM {T} p WHERE p.concept_uri=c.parent_uri AND p.facet_type=c.facet_type)""")
+        check("tree: every parent_uri resolves to a node", orph == 0, f"{orph} dangling parents")
+        # exactly one root per hierarchical dim
+        badroots = scalar(f"""SELECT COUNT(*) FROM (
+            SELECT facet_type, COUNT(*) n FROM {T} WHERE parent_uri IS NULL GROUP BY facet_type HAVING n<>1)""")
+        check("tree: exactly one root per dim", badroots == 0, f"{badroots} dims with !=1 root")
+        # all three hierarchical dims present (catches a silently-missing dim)
+        dims_present = scalar(f"SELECT COUNT(DISTINCT facet_type) FROM {T}")
+        check("tree: all 3 hierarchical dims present", dims_present == 3,
+              f"{dims_present} dims present (want material/context/object_type)")
+        # CROSS-FILE ALGEBRA: material root membership == facets_v2 non-root material
+        # (both = located samples carrying ≥1 non-root material concept).
+        mat_root = scalar(f"SELECT count FROM {T} WHERE facet_type='material' AND parent_uri IS NULL")
+        fv2_mat = scalar(f"SELECT COUNT(*) FROM {F} WHERE material IS NOT NULL")
+        check("tree: material root == facets_v2 non-root material count",
+              mat_root == fv2_mat, f"tree={mat_root:,} vs facets_v2={fv2_mat:,}")
+    if mem:
+        M = f"read_parquet('{mem}')"
+        dup = scalar(f"SELECT COUNT(*) FROM (SELECT pid,facet_type,concept_uri FROM {M} GROUP BY 1,2,3 HAVING COUNT(*)>1)")
+        check("membership: (pid,facet_type,concept_uri) unique", dup == 0, f"{dup} dup grain rows")
+        if tree:  # tree_summaries must EXACTLY equal a fresh GROUP BY of membership
+            T2 = f"read_parquet('{tree}')"
+            # symmetric: neither side has a (facet_type,concept,count) the other lacks
+            mm = scalar(f"""
+                WITH g AS (SELECT facet_type, concept_uri, COUNT(DISTINCT pid) AS count FROM {M} GROUP BY 1,2),
+                     t AS (SELECT facet_type, concept_uri, count FROM {T2})
+                SELECT (SELECT COUNT(*) FROM (SELECT * FROM g EXCEPT SELECT * FROM t))
+                     + (SELECT COUNT(*) FROM (SELECT * FROM t EXCEPT SELECT * FROM g))""")
+            check("tree counts == GROUP BY membership (symmetric)", mm == 0, f"{mm} rows disagree")
 
     print(f"\n{'CHECK':<44} {'RESULT':<6} DETAIL\n" + "-" * 90)
     ok = True


### PR DESCRIPTION
## #281/#282 Half (a) — facet hierarchy data pipeline (tree + membership + counts)

The **backend** half of the tree-facet feature. **No `explorer.qmd`/UI changes** — Half (b) (the tree UI) rides on the #249 refactor (PR4a/PR4b/#285, now merged). Branch off `main` (fork staging); data files publish versioned, non-cutover.

Grounded + proven, not assumed — see `FACET_HIERARCHY_PLAN.md` (Codex-reviewed design) and `scripts/poc_facet_hierarchy.py` (de-risking proof).

### What it builds
- **`build_vocab_labels.py`** — emit `broader` (canonical primary parent) + `broader_count` per concept, in both vocab-form and **data-form** (`/1.0/`) rows so `uri`↔`broader` join within each `uri_form`. The TTLs are *un-versioned*; the data is `/1.0/` — this reuses the existing `_data_form_uris` alias logic (a naive join is **0%** matches). DAG (multi-parent) count surfaced as a lossy-projection note.
- **`build_frontend_derived.py`** — `concept_tree` + recursive `concept_closure`; `node_dim` assigns each concept to the dim whose canonical root it reaches; **`sample_facet_membership`** (located universe `samp_geo`, full wide arrays expanded to ancestors, restricted to each dim's tree) and **`facet_tree_summaries`** (`COUNT(DISTINCT pid)` per node — **distinct-pid UNION, not additive**). Concepts with no path to their dim root are **excluded + reported** (flat `facet_summaries` still counts them).
- **`validate_frontend_derived.py`** — tree gate: parent≥child, every parent resolves, one root per dim, all 3 dims present, **cross-file algebra** (material root == `facets_v2` non-root material), membership grain unique, symmetric `tree == GROUP BY(membership)`.

### Verified (live 202608)
- 209-node tree; **38.9M** membership rows; material root **5,829,436 == `facets_v2` non-root material** ✓
- sane tree: material → earthmaterial → rockorsediment → rock; mineral 303K
- **all validator checks PASS**; **53 unit tests green** (`test_frontend_derived`, `test_vocabularies`, `test_ingest_oc_records`)
- excluded (label gaps / un-linked schemes): context=1, object_type=2, material=0

### Codex review (2 rounds, gpt-5.5)
Plan: "directionally sound." Pipeline: fixed both **HIGH** findings — root-dropping now per-dim-explicit (not every parentless concept), and orphan handling is explicit + honestly reported (was silently dropped). MEDIUMs done: fail-loud on explicit request w/o `--vocab-labels`, deterministic ordering, DAG surfacing, stronger symmetric/all-dims validator.

### Deferred (documented, not blockers)
Per-dim **DAG** paths (we keep one canonical parent — lossy tree projection); a SQL-literal helper for path interpolation (consistent with existing scripts); materializing the wide-array projection once (avoids 3× reread, remote-only concern).

### Next (Half b, separate)
Tree UI in `explorer.qmd` (2 levels unfolded, expand-to-open), membership filtering, behind the smoke + characterization + new tree specs. Material-first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
