### PR TITLE
#281/#282 Half(b) increment 1: Material facet tree (preview flag)

### DIFF
--- a/explorer.qmd
+++ b/explorer.qmd
@@ -904,6 +904,9 @@ function applyQueryToFacetFilters() {
     setCheckedValues('materialFilterBody', csvParamValues(params, 'material'));
     setCheckedValues('contextFilterBody', csvParamValues(params, 'context'));
     setCheckedValues('objectTypeFilterBody', csvParamValues(params, 'object_type'));
+    // #281/#282: restored ?material= URIs are the minimal nodes — fill in their
+    // inherited descendants + indeterminate ancestors so the tree looks right.
+    syncMaterialTreeVisual();
 }
 
 
@@ -954,7 +957,9 @@ function writeQueryState(opts = {}) {
         ['context', 'contextFilterBody'],
         ['object_type', 'objectTypeFilterBody'],
     ].forEach(([key, containerId]) => {
-        const values = getCheckedValues(containerId);
+        // #281/#282: serialize the MINIMAL Material selection in tree mode (parent
+        // URIs, not expanded descendants) so shared links stay compact + stable.
+        const values = (key === 'material') ? materialSelection() : getCheckedValues(containerId);
         if (values.length > 0) params.set(key, values.join(','));
         else params.delete(key);
     });
@@ -986,6 +991,73 @@ function hasFacetFilters() {
     return getCheckedValues('materialFilterBody').length > 0
         || getCheckedValues('contextFilterBody').length > 0
         || getCheckedValues('objectTypeFilterBody').length > 0;
+}
+
+// #281/#282: the MINIMAL Material selection — the top-most checked tree nodes
+// (a checked node whose ancestor is also checked is redundant, since the parent's
+// subtree already covers it). This is the canonical selection used for filtering
+// and URL serialization in tree mode; flat mode falls back to all checked values.
+// #281/#282: the SINGLE source of truth for "Material is actually in tree mode" —
+// the flag is on AND the tree rendered (renderMaterialTreeFacet falls back to the
+// flat list if the hierarchy files fail to load). Every material code path keys off
+// this, so a degraded flat fallback behaves fully flat — selection, filtering, AND
+// cross-filter counts (Codex r2). Without it, filtering would query the missing
+// membership file and counts would wrongly exclude material.
+function materialTreeActive() {
+    return FACET_TREE && !!document.querySelector('#materialFilterBody .facet-treenode');
+}
+
+function materialSelection() {
+    if (!materialTreeActive()) return getCheckedValues('materialFilterBody');
+    const body = document.getElementById('materialFilterBody');
+    const out = [];
+    body.querySelectorAll('.facet-treenode > .facet-treelabel input[type="checkbox"]:checked').forEach(cb => {
+        const node = cb.closest('.facet-treenode');
+        let anc = node && node.parentElement ? node.parentElement.closest('.facet-treenode') : null;
+        let covered = false;
+        while (anc) {
+            const a = anc.querySelector(':scope > .facet-treelabel input[type="checkbox"]');
+            if (a && a.checked && !a.disabled) { covered = true; break; }  // explicit ancestor covers it
+            anc = anc.parentElement ? anc.parentElement.closest('.facet-treenode') : null;
+        }
+        if (!covered) out.push(cb.value);
+    });
+    return out;
+}
+
+// #281/#282: keep the tree's visual state coherent after any change or URL restore:
+//  - a checked parent visually fills in its descendants (checked + disabled =
+//    "included because the parent is"), so the redundancy is obvious;
+//  - unchecking a parent reverts those inherited descendants;
+//  - a parent with some (but not all-via-itself) descendants selected shows the
+//    indeterminate "–" state. Filtering reads materialSelection() (top-most), so
+//    the inherited descendant checks never double-count.
+function syncMaterialTreeVisual() {
+    if (!materialTreeActive()) return;
+    const body = document.getElementById('materialFilterBody');
+    if (!body) return;
+    const cbOf = (node) => node.querySelector(':scope > .facet-treelabel input[type="checkbox"]');
+    const nodes = [...body.querySelectorAll('.facet-treenode')];  // DOM order = parents before children
+    // Pass 1 (top-down): inherit checked state from an explicitly-checked ancestor.
+    for (const node of nodes) {
+        const cb = cbOf(node);
+        if (!cb) continue;
+        let anc = node.parentElement ? node.parentElement.closest('.facet-treenode') : null;
+        let coveredByAnc = false;
+        while (anc) {
+            const a = cbOf(anc);
+            if (a && a.checked && !a.disabled) { coveredByAnc = true; break; }
+            anc = anc.parentElement ? anc.parentElement.closest('.facet-treenode') : null;
+        }
+        if (coveredByAnc) { cb.checked = true; cb.disabled = true; cb.indeterminate = false; }
+        else if (cb.disabled) { cb.disabled = false; cb.checked = false; }  // was inherited, parent now off → revert
+    }
+    // Pass 2: indeterminate when not selected itself but a descendant is checked.
+    for (const node of nodes) {
+        const cb = cbOf(node);
+        if (!cb) continue;
+        cb.indeterminate = (!cb.checked) && !!node.querySelector(':scope > .facet-children input[type="checkbox"]:checked');
+    }
 }
 
 // Single source of truth for #facetNote visibility. The note ("filter
@@ -1021,7 +1093,7 @@ function syncFacetNote() {
 // (a sample with two materials would appear twice via JOIN). Required
 // for Phase 4's table mode and any non-JOIN caller. See issue #156.
 function facetFilterSQL() {
-    const mat = getCheckedValues('materialFilterBody');
+    const mat = materialSelection();   // minimal (top-most) nodes in tree mode
     const ctx = getCheckedValues('contextFilterBody');
     const ot  = getCheckedValues('objectTypeFilterBody');
 
@@ -1034,7 +1106,7 @@ function facetFilterSQL() {
     const facetsConds = [];
     if (mat.length > 0) {
         const list = mat.map(s => `'${escSql(s)}'`).join(',');
-        if (FACET_TREE) {
+        if (materialTreeActive()) {
             parts.push(`pid IN (SELECT DISTINCT pid FROM read_parquet('${membership_url}') WHERE facet_type='material' AND concept_uri IN (${list}))`);
         } else {
             facetsConds.push(`material IN (${list})`);
@@ -1941,6 +2013,10 @@ facetFilters = {
                 const kids = node && node.querySelector(':scope > .facet-children');
                 if (kids) { const collapsed = kids.classList.toggle('collapsed'); c.textContent = collapsed ? '▸' : '▾'; }
             }));
+            // Tri-state + inherited-check visual sync on any checkbox toggle. Filtering
+            // reads materialSelection() (top-most) so inherited checks don't double-count.
+            body.addEventListener('change', () => syncMaterialTreeVisual());
+            syncMaterialTreeVisual();  // initial (in case ?material= pre-checked nodes)
         }
         if (FACET_TREE) { await renderMaterialTreeFacet(); }
         else { renderFilter('materialFilterBody', 'material', grouped.material); }
@@ -2938,7 +3014,7 @@ zoomWatcher = {
         // and a selected parent node wouldn't match facets_v3's flat values). The
         // table/map still filter correctly via facetFilterSQL's membership path.
         // Viewport/cross-filtered material tree counts are the next increment.
-        const mat = FACET_TREE ? [] : getCheckedValues('materialFilterBody');
+        const mat = materialTreeActive() ? [] : getCheckedValues('materialFilterBody');
         const ctx = getCheckedValues('contextFilterBody');
         const ot = getCheckedValues('objectTypeFilterBody');
         const dims = [

--- a/explorer.qmd
+++ b/explorer.qmd
@@ -578,6 +578,15 @@ format:
     .facet-row.zero { opacity: 0.4; }
     .facet-row.zero:hover { opacity: 0.65; }
     .facet-count.recomputing { opacity: 0.55; font-style: italic; }
+    /* #281/#282 Material tree (preview) */
+    .facet-treeroot { font-weight: 600; font-size: 12px; padding: 2px 0; color: #444; }
+    .facet-treelabel { display: inline; }
+    .facet-children { margin-left: 14px; }
+    .facet-children.collapsed { display: none; }
+    .facet-caret { cursor: pointer; display: inline-block; width: 1em; color: #888; user-select: none; }
+    .facet-caret:hover { color: #1565c0; }
+    .facet-caret-spacer { display: inline-block; width: 1em; }
+    .facet-treenode { font-size: 12px; }
 </style>
 ```
 
@@ -766,6 +775,22 @@ cross_filter_url = `${R2_BASE}/isamples_202608_facet_cross_filter.parquet`
 // SKOS prefLabels for Material / Sampled Feature / Specimen Type URIs.
 // ~60 KB lookup; falls back to URI tail if a URI isn't covered.
 vocab_labels_url = `${R2_BASE}/vocab_labels_202608.parquet`
+
+// #281/#282 facet hierarchy PREVIEW (default OFF — the flat Material list is
+// unchanged for everyone). Opt in with ?facets=tree (force off with ?facets=flat),
+// or stickily via localStorage ISAMPLES_FACET_TREE=1. When on, the Material facet
+// renders as an expandable tree backed by the hierarchy artifacts below; context /
+// object_type / source stay flat. Reversible = a single switch.
+FACET_TREE = (() => {
+    const q = new URLSearchParams(location.search).get('facets');
+    if (q === 'tree') return true;
+    if (q === 'flat') return false;
+    return (typeof localStorage !== 'undefined' && localStorage.getItem('ISAMPLES_FACET_TREE') === '1');
+})()
+// Hierarchical counts (one row per concept node: facet_type, concept_uri,
+// parent_uri, depth, count) and per-sample membership (pid ↔ every ancestor).
+facet_tree_url = `${R2_BASE}/isamples_202608_facet_tree_summaries.parquet`
+membership_url = `${R2_BASE}/isamples_202608_sample_facet_membership.parquet`
 
 // Canonical palette — see issue #113. Path-relative so this works under
 // both isamples.org (custom domain at root) and project-pages fork
@@ -998,21 +1023,34 @@ function facetFilterSQL() {
     const ctx = getCheckedValues('contextFilterBody');
     const ot  = getCheckedValues('objectTypeFilterBody');
 
-    const conds = [];
+    // Each entry is a standalone `pid IN (...)` predicate; multiple are AND-ed.
+    const parts = [];
+    // #281/#282: in tree mode the Material selection is a set of concept nodes;
+    // filter via the membership table (which encodes each sample under every
+    // ancestor), so selecting a parent node matches its whole subtree — no
+    // client-side descendant expansion. context/object_type stay flat on facets.
+    const facetsConds = [];
     if (mat.length > 0) {
         const list = mat.map(s => `'${escSql(s)}'`).join(',');
-        conds.push(`material IN (${list})`);
+        if (FACET_TREE) {
+            parts.push(`pid IN (SELECT DISTINCT pid FROM read_parquet('${membership_url}') WHERE facet_type='material' AND concept_uri IN (${list}))`);
+        } else {
+            facetsConds.push(`material IN (${list})`);
+        }
     }
     if (ctx.length > 0) {
         const list = ctx.map(s => `'${escSql(s)}'`).join(',');
-        conds.push(`context IN (${list})`);
+        facetsConds.push(`context IN (${list})`);
     }
     if (ot.length > 0) {
         const list = ot.map(s => `'${escSql(s)}'`).join(',');
-        conds.push(`object_type IN (${list})`);
+        facetsConds.push(`object_type IN (${list})`);
     }
-    if (conds.length === 0) return '';
-    return ` AND pid IN (SELECT DISTINCT pid FROM read_parquet('${facets_url}') WHERE ${conds.join(' AND ')})`;
+    if (facetsConds.length > 0) {
+        parts.push(`pid IN (SELECT DISTINCT pid FROM read_parquet('${facets_url}') WHERE ${facetsConds.join(' AND ')})`);
+    }
+    if (parts.length === 0) return '';
+    return ' AND ' + parts.map(p => `(${p})`).join(' AND ');
 }
 
 // Shared viewport-padding factor. The samples table (PR #219), the
@@ -1852,7 +1890,58 @@ facetFilters = {
             ).join('');
         };
 
-        renderFilter('materialFilterBody', 'material', grouped.material);
+        // #281/#282: render Material as an expandable tree when the preview flag
+        // is on; flat list otherwise. context/object_type/source stay flat.
+        // Defined inline so it closes over prettyLabel / escapers / grouped / db.
+        async function renderMaterialTreeFacet() {
+            const body = document.getElementById('materialFilterBody');
+            if (!body) return;
+            let rows;
+            try {
+                rows = await db.query(`SELECT concept_uri, parent_uri, depth, count FROM read_parquet('${facet_tree_url}') WHERE facet_type='material'`);
+            } catch (err) {
+                console.warn('facet_tree load failed; flat material fallback:', err);
+                renderFilter('materialFilterBody', 'material', grouped.material);
+                return;
+            }
+            const nodes = new Map();
+            for (const r of rows) nodes.set(r.concept_uri, { uri: r.concept_uri, parent: r.parent_uri, depth: Number(r.depth), count: Number(r.count), label: prettyLabel(r.concept_uri), kids: [] });
+            let root = null;
+            for (const n of nodes.values()) { if (n.parent == null) root = n; else if (nodes.has(n.parent)) nodes.get(n.parent).kids.push(n); }
+            for (const n of nodes.values()) n.kids.sort((a, b) => a.label.localeCompare(b.label));  // #282 alphabetical within level
+            // Material baseline counts must come from the tree (Codex), not the flat summaries.
+            viewer._baselineCounts.material = new Map([...nodes.values()].map(n => [n.uri, n.count]));
+            // First two levels unfolded (#281): depth 1 + 2 visible; depth ≥3 collapsed.
+            const nodeHtml = (n) => {
+                const hasKids = n.kids.length > 0;
+                const open = hasKids && n.depth < 2;
+                const caret = hasKids
+                    ? `<span class="facet-caret" role="button" aria-label="expand or collapse">${open ? '▾' : '▸'}</span>`
+                    : `<span class="facet-caret-spacer"></span>`;
+                return `<div class="facet-treenode" data-depth="${n.depth}">`
+                    + caret
+                    + `<label class="facet-row facet-treelabel" data-facet="material" data-value="${escAttr(n.uri)}" title="${escAttr(n.uri)}">`
+                    + `<input type="checkbox" value="${escAttr(n.uri)}"> ${escText(n.label)} `
+                    + `<span class="facet-count" data-facet="material" data-value="${escAttr(n.uri)}" style="color:#999">(${n.count.toLocaleString()})</span>`
+                    + `</label>`
+                    + (hasKids ? `<div class="facet-children${open ? '' : ' collapsed'}">` + n.kids.map(nodeHtml).join('') + `</div>` : '')
+                    + `</div>`;
+            };
+            // Root renders as a non-selectable "All …" grouping label (selecting it = no filter).
+            body.innerHTML =
+                `<div class="facet-treeroot">${escText(root ? root.label : 'All materials')}`
+                + (root ? ` <span class="facet-count" data-facet="material" data-value="${escAttr(root.uri)}" style="color:#999">(${root.count.toLocaleString()})</span>` : '')
+                + `</div>`
+                + (root ? root.kids.map(nodeHtml).join('') : '');
+            body.querySelectorAll('.facet-caret').forEach(c => c.addEventListener('click', (e) => {
+                e.preventDefault(); e.stopPropagation();
+                const node = c.closest('.facet-treenode');
+                const kids = node && node.querySelector(':scope > .facet-children');
+                if (kids) { const collapsed = kids.classList.toggle('collapsed'); c.textContent = collapsed ? '▸' : '▾'; }
+            }));
+        }
+        if (FACET_TREE) { await renderMaterialTreeFacet(); }
+        else { renderFilter('materialFilterBody', 'material', grouped.material); }
         renderFilter('contextFilterBody', 'context', grouped.context);
         renderFilter('objectTypeFilterBody', 'object_type', grouped.object_type);
         applyFacetCounts('source', null);
@@ -2841,7 +2930,13 @@ zoomWatcher = {
         const sourceChecks = document.querySelectorAll('#sourceFilter input[type="checkbox"]');
         const sourceTotal = sourceChecks.length;
         const sources = getActiveSources();
-        const mat = getCheckedValues('materialFilterBody');
+        // #281/#282 increment 1: in tree mode the Material facet keeps its
+        // STATIC tree baseline counts and is excluded from the live cross-filter
+        // count engine (its counts come from facet_tree_summaries, not facets_v3,
+        // and a selected parent node wouldn't match facets_v3's flat values). The
+        // table/map still filter correctly via facetFilterSQL's membership path.
+        // Viewport/cross-filtered material tree counts are the next increment.
+        const mat = FACET_TREE ? [] : getCheckedValues('materialFilterBody');
         const ctx = getCheckedValues('contextFilterBody');
         const ot = getCheckedValues('objectTypeFilterBody');
         const dims = [

--- a/explorer.qmd
+++ b/explorer.qmd
@@ -578,15 +578,17 @@ format:
     .facet-row.zero { opacity: 0.4; }
     .facet-row.zero:hover { opacity: 0.65; }
     .facet-count.recomputing { opacity: 0.55; font-style: italic; }
-    /* #281/#282 Material tree (preview) */
-    .facet-treeroot { font-weight: 600; font-size: 12px; padding: 2px 0; color: #444; }
-    .facet-treelabel { display: inline; }
-    .facet-children { margin-left: 14px; }
+    /* #281/#282 Material tree (preview) — compact rows */
+    .filter-body .facet-treeroot { font-weight: 600; font-size: 12px; line-height: 1.5; padding: 0 0 2px; color: #444; }
+    .filter-body .facet-treenode { font-size: 12px; line-height: 1.5; }
+    /* override .filter-body label{display:block;padding:2px 0} so caret+label+count
+       sit on one tight line with no extra per-row padding */
+    .filter-body .facet-treenode .facet-treelabel { display: inline; padding: 0; cursor: pointer; }
+    .facet-children { margin-left: 13px; }
     .facet-children.collapsed { display: none; }
-    .facet-caret { cursor: pointer; display: inline-block; width: 1em; color: #888; user-select: none; }
+    .facet-caret { cursor: pointer; display: inline-block; width: 12px; color: #888; user-select: none; font-size: 10px; }
     .facet-caret:hover { color: #1565c0; }
-    .facet-caret-spacer { display: inline-block; width: 1em; }
-    .facet-treenode { font-size: 12px; }
+    .facet-caret-spacer { display: inline-block; width: 12px; }
 </style>
 ```
 

--- a/tests/playwright/facet-tree.spec.js
+++ b/tests/playwright/facet-tree.spec.js
@@ -68,4 +68,101 @@ test.describe('Material facet tree (#281/#282 preview)', () => {
     });
     expect(total).toBeGreaterThan(0);
   });
+
+  // Known 202608 subtree/union totals — deterministic for this dataset, so polling
+  // to the exact value also guarantees the filter has applied (no stale-pager read).
+  const EARTHMATERIAL_TOTAL = 4091133;        // earthmaterial subtree
+  const MINERAL_OR_SOIL_TOTAL = 333253;       // mineral ∪ soil (peers)
+
+  test('polish: checking a parent inherits its children (checked+disabled); peers go OR with an indeterminate parent', async ({ page }) => {
+    const toggle = (sub, val) => page.evaluate(({ sub, val }) => {
+      const cb = document.querySelector(`#materialFilterBody input[value*="${sub}"]`);
+      cb.checked = val; cb.dispatchEvent(new Event('change', { bubbles: true }));
+    }, { sub, val });
+    const total = async () => page.evaluate(() => {
+      const m = (document.getElementById('tablePageInfo')?.textContent || '').match(/of ([\d,]+)\)/);
+      return m ? parseInt(m[1].replace(/,/g, ''), 10) : null;
+    });
+    await page.goto(`/explorer.html?facets=tree${DATA}${WORLD}`);
+    await page.waitForFunction(
+      () => document.querySelectorAll('#materialFilterBody .facet-treenode').length > 0,
+      null, { timeout: 90000 });
+
+    // Check the "earthmaterial" parent → a child ("mineral") becomes inherited
+    // (checked + disabled), and the table filters to the whole subtree.
+    await toggle('/earthmaterial', true);
+    const child = await page.evaluate(() => {
+      const cb = document.querySelector('#materialFilterBody input[value*="/mineral"]');
+      return { checked: cb.checked, disabled: cb.disabled };
+    });
+    expect(child).toEqual({ checked: true, disabled: true });
+    await expect.poll(total, { timeout: 60000, intervals: [500, 1000, 2000] }).toBe(EARTHMATERIAL_TOTAL);
+
+    // Uncheck the parent; check two PEERS (mineral + soil) → the parent shows the
+    // indeterminate "–" state, and the table is their OR/union (smaller than the parent).
+    await toggle('/earthmaterial', false);
+    await toggle('/mineral', true);
+    await toggle('/soil', true);
+    const parentState = await page.evaluate(() => {
+      const cb = document.querySelector('#materialFilterBody input[value*="/earthmaterial"]');
+      return { checked: cb.checked, indeterminate: cb.indeterminate };
+    });
+    expect(parentState).toEqual({ checked: false, indeterminate: true });
+    await expect.poll(total, { timeout: 60000, intervals: [500, 1000, 2000] }).toBe(MINERAL_OR_SOIL_TOTAL);
+    expect(MINERAL_OR_SOIL_TOTAL).toBeLessThan(EARTHMATERIAL_TOTAL);
+  });
+
+  test('URL round-trip: a parent selection serializes the minimal node and restores inherited state', async ({ page }) => {
+    const EARTHMATERIAL = 'https://w3id.org/isample/vocabulary/material/1.0/earthmaterial';
+    // Select earthmaterial, then assert the URL carries ONLY that node (minimal — no
+    // expanded descendants like /mineral).
+    await page.goto(`/explorer.html?facets=tree${DATA}${WORLD}`);
+    await page.waitForFunction(() => document.querySelectorAll('#materialFilterBody .facet-treenode').length > 0, null, { timeout: 90000 });
+    await page.evaluate(() => {
+      const cb = document.querySelector('#materialFilterBody input[value*="/earthmaterial"]');
+      cb.checked = true; cb.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    await expect.poll(async () => {
+      const p = new URLSearchParams(new URL(await page.evaluate(() => location.href)).search);
+      return p.get('material');
+    }, { timeout: 30000, intervals: [250, 500, 1000] }).toBe(EARTHMATERIAL);
+    const url = await page.evaluate(() => location.href);
+    expect(url).not.toContain('mineral');  // descendants are NOT expanded into the URL
+
+    // Reload that URL fresh → earthmaterial restored as selected, and a child shows
+    // the inherited (checked + disabled) state.
+    await page.goto(url.includes('data_base') ? url : `${url}${DATA.replace('&', url.includes('?') ? '&' : '?')}`);
+    await page.waitForFunction(() => document.querySelectorAll('#materialFilterBody .facet-treenode').length > 0, null, { timeout: 90000 });
+    const restored = await page.evaluate(() => {
+      const par = document.querySelector('#materialFilterBody input[value*="/earthmaterial"]');
+      const kid = document.querySelector('#materialFilterBody input[value*="/mineral"]');
+      return { parentChecked: par.checked, kidChecked: kid.checked, kidDisabled: kid.disabled };
+    });
+    expect(restored).toEqual({ parentChecked: true, kidChecked: true, kidDisabled: true });
+  });
+
+  test('graceful fallback: if the tree data 404s, Material renders flat and still filters', async ({ page }) => {
+    // Deploy-safety (Codex r2/r3): with ?facets=tree but the hierarchy files
+    // missing, renderMaterialTreeFacet() catches and renders the flat list, and
+    // materialTreeActive() is false everywhere → selection/filtering use the flat
+    // facets_v3 path (NOT the missing membership file).
+    await page.route('**/*facet_tree_summaries*', route => route.fulfill({ status: 404, body: '' }));
+    await page.goto(`/explorer.html?facets=tree${DATA}${WORLD}`);
+    await page.waitForFunction(
+      () => document.querySelectorAll('#materialFilterBody .facet-row[data-facet="material"]').length > 0,
+      null, { timeout: 90000 });
+    const treenodes = await page.evaluate(() => document.querySelectorAll('#materialFilterBody .facet-treenode').length);
+    expect(treenodes).toBe(0);  // fell back to flat
+    // a flat material selection still filters the table (uses facets_v3, no membership)
+    await page.evaluate(() => {
+      const cb = document.querySelector('#materialFilterBody input[type="checkbox"]');
+      cb.checked = true; cb.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    await page.waitForFunction(() => /of [\d,]+\)/.test(document.getElementById('tablePageInfo')?.textContent || ''), null, { timeout: 60000 });
+    const total = await page.evaluate(() => {
+      const m = (document.getElementById('tablePageInfo')?.textContent || '').match(/of ([\d,]+)\)/);
+      return m ? parseInt(m[1].replace(/,/g, ''), 10) : null;
+    });
+    expect(total).toBeGreaterThan(0);
+  });
 });

--- a/tests/playwright/facet-tree.spec.js
+++ b/tests/playwright/facet-tree.spec.js
@@ -1,0 +1,71 @@
+/**
+ * #281/#282 Half(b) increment 1 — Material facet hierarchy (preview flag).
+ *
+ * Verifies the `?facets=tree` preview: flag OFF leaves Material flat (unchanged);
+ * flag ON renders the expandable tree and selecting a node filters the table to
+ * that node's whole SUBTREE via the membership table (no client-side expansion).
+ *
+ * GATED: needs the hierarchy data (facet_tree_summaries / sample_facet_membership /
+ * vocab_labels-with-broader). Until those are published to R2, run against the local
+ * docs/data mirror:
+ *   FACET_TREE_LOCAL=1 TEST_URL=http://localhost:5860 npx playwright test facet-tree
+ * (the spec drives ?data_base=/data). Skipped by default so CI stays green until the
+ * R2 publish; flip the skip / drop ?data_base once the files are remote.
+ */
+const { test, expect } = require('@playwright/test');
+
+const LOCAL = !!process.env.FACET_TREE_LOCAL;
+const DATA = LOCAL ? '&data_base=/data' : '';
+const WORLD = '#v=1&lat=20&lng=0&alt=10000000';
+
+test.describe('Material facet tree (#281/#282 preview)', () => {
+  test.skip(!LOCAL, 'needs hierarchy data — run with FACET_TREE_LOCAL=1 against the docs/data mirror until R2 publish');
+  test.setTimeout(150000);
+
+  test('flag OFF → Material stays a flat list (no tree nodes)', async ({ page }) => {
+    await page.goto(`/explorer.html?facets=flat${DATA}${WORLD}`);
+    await page.waitForFunction(
+      () => document.querySelectorAll('#materialFilterBody .facet-row[data-facet="material"]').length > 0,
+      null, { timeout: 90000 });
+    const treenodes = await page.evaluate(() => document.querySelectorAll('#materialFilterBody .facet-treenode').length);
+    expect(treenodes).toBe(0);
+  });
+
+  test('flag ON → tree renders; selecting a parent filters the table to its subtree', async ({ page }) => {
+    await page.goto(`/explorer.html?facets=tree${DATA}${WORLD}`);
+    await page.waitForFunction(
+      () => document.querySelectorAll('#materialFilterBody .facet-treenode').length > 0,
+      null, { timeout: 90000 });
+
+    // Tree structure: a non-selectable root group, several nodes, carets, and the
+    // deepest level collapsed (first two levels unfolded, #281).
+    const info = await page.evaluate(() => ({
+      nodes: document.querySelectorAll('#materialFilterBody .facet-treenode').length,
+      hasRoot: !!document.querySelector('#materialFilterBody .facet-treeroot'),
+      carets: document.querySelectorAll('#materialFilterBody .facet-caret').length,
+      collapsed: document.querySelectorAll('#materialFilterBody .facet-children.collapsed').length,
+      earthmaterial: !!document.querySelector('#materialFilterBody input[value*="/earthmaterial"]'),
+    }));
+    expect(info.nodes).toBeGreaterThan(5);
+    expect(info.hasRoot).toBe(true);
+    expect(info.carets).toBeGreaterThan(0);
+    expect(info.collapsed).toBeGreaterThan(0);
+    expect(info.earthmaterial).toBe(true);
+
+    // Selecting the "earthmaterial" parent must filter the table to its whole
+    // subtree (membership encodes ancestors → no client expansion needed).
+    await page.evaluate(() => {
+      const cb = document.querySelector('#materialFilterBody input[value*="/earthmaterial"]');
+      cb.checked = true;
+      document.getElementById('materialFilterBody').dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    await page.waitForFunction(
+      () => /of [\d,]+\)/.test(document.getElementById('tablePageInfo')?.textContent || ''),
+      null, { timeout: 60000 });
+    const total = await page.evaluate(() => {
+      const m = (document.getElementById('tablePageInfo')?.textContent || '').match(/of ([\d,]+)\)/);
+      return m ? parseInt(m[1].replace(/,/g, ''), 10) : null;
+    });
+    expect(total).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## #281/#282 Half (b) increment 1 — Material facet **tree**, behind a preview flag

The user-facing half of the hierarchy (data pipeline = #16, merged). **Behind a preview switch, default OFF** — the live flat Material list is byte-identical for everyone:
- `?facets=tree` opts in · `?facets=flat` forces off · `localStorage ISAMPLES_FACET_TREE=1` sticky.
- **Reversible = one switch.** Exactly the "let Eric try it, easy to undo" shape.

### What works (verified headless on 202608)
- Material renders as an **expandable tree** from `facet_tree_summaries`: non-selectable root ("All materials"), **first two levels unfolded** (#281), deeper collapsed behind carets, **alphabetical within level** (#282).
- Material **baseline counts from `facet_tree_summaries`** (Codex amendment), not the flat summaries.
- **Subtree filtering via membership** — selecting a parent filters the table/map to its *whole subtree* by filtering on the parent URI alone (membership encodes every ancestor; no client-side expansion). Verified: select `earthmaterial` → table = **4,091,133** (exactly its subtree count).
- `facetFilterSQL` stays the **single shared predicate** (table + map + point-mode); material → membership subquery when on, AND-combined with the flat context/object_type subquery.
- **Flag OFF is unchanged** — identical `facets_v3` subquery, `describeCrossFilters` reads material as before. **Smoke gate green.**

### Deferred to increment 2 (documented in the commit)
- **Live viewport/cross-filtered Material counts** — in tree mode Material shows *static* tree baseline counts and is excluded from the live count engine (`facets_v3` can't answer parent-node counts). **Table/map filtering is fully live + correct**; only the legend numbers are static for now.
- Tri-state parent display + auto-check descendants; accessibility (`role=tree`/aria); context/object_type trees; latency probe + optional cube.

### To get a live preview link for Eric
The 3 hierarchy files need to be on R2 (gated prod-data publish) — or a preview deploy. Until then the tree runs against the local `docs/data` mirror.

### Tests
`tests/playwright/facet-tree.spec.js` — flag-off flat, flag-on tree + subtree filter. Gated on `FACET_TREE_LOCAL=1` + the mirror until the files are on R2 (skipped in CI so it stays green). Render clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
